### PR TITLE
Add gc-review-im skill for GoC Information Management

### DIFF
--- a/skills/gc-review-im/CONFIG.md
+++ b/skills/gc-review-im/CONFIG.md
@@ -1,0 +1,387 @@
+# gc-review-im Configuration
+
+This document describes the configuration schema for the `gc-review-im` skill.
+
+## Configuration File Locations
+
+**Project config (highest priority):**
+```
+.gc-review/config.json
+```
+
+**User config (fallback):**
+```
+~/.gc-review/config.json
+```
+
+If neither exists, default settings are used.
+
+---
+
+## Configuration Schema
+
+```json
+{
+  "version": 1,
+  "requiredMetadata": ["record_id", "creator_id", "date_created", "language", "classification"],
+  "softDeleteFields": ["deleted_at", "is_deleted", "archived_at"],
+  "retentionFields": ["retention_schedule", "disposition_date", "retention_code", "retention_period"],
+  "exclude": ["**/test/**", "**/tests/**", "*.spec.ts", "*.test.ts"],
+  "includePatterns": [],
+  "strictMode": false
+}
+```
+
+---
+
+## Field Definitions
+
+### version
+**Type:** `number`
+**Required:** Yes
+**Description:** Configuration schema version. Currently `1`.
+
+```json
+{
+  "version": 1
+}
+```
+
+---
+
+### requiredMetadata
+**Type:** `string[]`
+**Required:** No
+**Default:** `["record_id", "creator_id", "date_created", "language", "classification"]`
+**Description:** List of metadata fields required on business record models.
+
+Each field can have acceptable variants that will be recognized:
+
+| Field | Recognized Variants |
+|-------|---------------------|
+| `record_id` | `id`, `uuid`, `record_uuid` |
+| `creator_id` | `created_by`, `author_id`, `owner_id`, `creatorId` |
+| `date_created` | `created_at`, `creation_date`, `created_date`, `createdAt` |
+| `language` | `lang`, `locale`, `content_language` |
+| `classification` | `security_classification`, `security_level`, `protected_level` |
+
+**Example - Adding custom required field:**
+```json
+{
+  "requiredMetadata": [
+    "record_id",
+    "creator_id",
+    "date_created",
+    "language",
+    "classification",
+    "department_code"
+  ]
+}
+```
+
+**Example - Minimal requirements:**
+```json
+{
+  "requiredMetadata": [
+    "creator_id",
+    "date_created"
+  ]
+}
+```
+
+---
+
+### softDeleteFields
+**Type:** `string[]`
+**Required:** No
+**Default:** `["deleted_at", "is_deleted", "archived_at"]`
+**Description:** Field names that indicate soft delete support. If a model has one of these fields, hard delete warnings may be suppressed.
+
+**Example:**
+```json
+{
+  "softDeleteFields": [
+    "deleted_at",
+    "is_deleted",
+    "archived_at",
+    "status",
+    "is_active"
+  ]
+}
+```
+
+---
+
+### retentionFields
+**Type:** `string[]`
+**Required:** No
+**Default:** `["retention_schedule", "disposition_date", "retention_code", "retention_period"]`
+**Description:** Field names that indicate retention/disposition support.
+
+**Example:**
+```json
+{
+  "retentionFields": [
+    "retention_schedule",
+    "disposition_date",
+    "retention_code",
+    "disposal_authority",
+    "records_schedule_code"
+  ]
+}
+```
+
+---
+
+### exclude
+**Type:** `string[]`
+**Required:** No
+**Default:** `[]`
+**Description:** Glob patterns for files to exclude from review.
+
+**Common patterns:**
+```json
+{
+  "exclude": [
+    "**/test/**",
+    "**/tests/**",
+    "**/__tests__/**",
+    "*.spec.ts",
+    "*.test.ts",
+    "**/fixtures/**",
+    "**/seeds/**",
+    "**/migrations/*.down.sql"
+  ]
+}
+```
+
+---
+
+### includePatterns
+**Type:** `string[]`
+**Required:** No
+**Default:** `[]` (uses built-in patterns)
+**Description:** Additional glob patterns for files to include in review. Extends the default patterns.
+
+**Example - Adding custom patterns:**
+```json
+{
+  "includePatterns": [
+    "**/domain/*.ts",
+    "**/aggregates/**/*.ts"
+  ]
+}
+```
+
+---
+
+### strictMode
+**Type:** `boolean`
+**Required:** No
+**Default:** `false`
+**Description:** When enabled, all warnings are treated as errors.
+
+```json
+{
+  "strictMode": true
+}
+```
+
+**Effect:**
+- Non-descriptive field names → ❌ Fail (instead of ⚠️ Warning)
+- Missing audit trail → ❌ Fail (instead of ⚠️ Warning)
+- Missing indexes → ❌ Fail (instead of ⚠️ Warning)
+
+---
+
+## Complete Example Configurations
+
+### Minimal Project Config
+
+```json
+{
+  "version": 1,
+  "exclude": ["**/test/**"]
+}
+```
+
+### Full Project Config
+
+```json
+{
+  "version": 1,
+  "requiredMetadata": [
+    "record_id",
+    "creator_id",
+    "date_created",
+    "language",
+    "classification",
+    "department_code"
+  ],
+  "softDeleteFields": [
+    "deleted_at",
+    "is_deleted",
+    "archived_at",
+    "status"
+  ],
+  "retentionFields": [
+    "retention_schedule",
+    "disposition_date",
+    "retention_code",
+    "disposal_authority"
+  ],
+  "exclude": [
+    "**/test/**",
+    "**/tests/**",
+    "**/__tests__/**",
+    "*.spec.ts",
+    "*.test.ts",
+    "**/fixtures/**",
+    "**/seeds/**"
+  ],
+  "includePatterns": [
+    "**/domain/**/*.ts"
+  ],
+  "strictMode": false
+}
+```
+
+### Strict Government Production Config
+
+```json
+{
+  "version": 1,
+  "requiredMetadata": [
+    "record_id",
+    "creator_id",
+    "date_created",
+    "language",
+    "classification",
+    "department_code",
+    "retention_code"
+  ],
+  "strictMode": true,
+  "exclude": []
+}
+```
+
+---
+
+## Validation Rules
+
+### File Existence
+1. Check if config file exists
+2. If missing, proceed to next precedence level
+3. If no config found, use defaults
+
+### JSON Validation
+```bash
+# Validate JSON syntax
+jq empty .gc-review/config.json 2>&1
+```
+
+If invalid JSON:
+```
+⚠️  Invalid JSON in .gc-review/config.json: {error}
+Using default configuration.
+```
+
+### Field Validation
+
+| Field | Validation |
+|-------|------------|
+| `version` | Must be number, currently `1` |
+| `requiredMetadata` | Must be array of strings |
+| `softDeleteFields` | Must be array of strings |
+| `retentionFields` | Must be array of strings |
+| `exclude` | Must be array of strings (glob patterns) |
+| `includePatterns` | Must be array of strings (glob patterns) |
+| `strictMode` | Must be boolean |
+
+### Invalid Field Handling
+
+If a field has invalid type:
+```
+⚠️  Invalid config: {field} must be {expected_type}, got {actual_type}
+Using default value for {field}.
+```
+
+### Unknown Field Handling
+
+Unknown fields are ignored with a warning:
+```
+⚠️  Unknown config field: {field_name} (ignored)
+```
+
+---
+
+## Config Precedence Examples
+
+### Scenario 1: Project config only
+
+```
+.gc-review/config.json exists → use project config
+```
+
+### Scenario 2: User config only
+
+```
+.gc-review/config.json missing
+~/.gc-review/config.json exists → use user config
+```
+
+### Scenario 3: Both exist
+
+```
+.gc-review/config.json exists → use project config
+~/.gc-review/config.json ignored
+```
+
+### Scenario 4: Neither exists
+
+```
+.gc-review/config.json missing
+~/.gc-review/config.json missing
+→ use default configuration
+```
+
+---
+
+## Setting Up Configuration
+
+### Create project config
+
+```bash
+mkdir -p .gc-review
+cat > .gc-review/config.json << 'EOF'
+{
+  "version": 1,
+  "exclude": ["**/test/**", "**/tests/**"]
+}
+EOF
+```
+
+### Create user config
+
+```bash
+mkdir -p ~/.gc-review
+cat > ~/.gc-review/config.json << 'EOF'
+{
+  "version": 1,
+  "strictMode": false
+}
+EOF
+```
+
+### Add to .gitignore (optional)
+
+If you want project-specific config to be shared:
+```
+# Keep .gc-review/config.json tracked
+```
+
+If you want it ignored:
+```
+# .gitignore
+.gc-review/
+```

--- a/skills/gc-review-im/SKILL.md
+++ b/skills/gc-review-im/SKILL.md
@@ -1,0 +1,598 @@
+---
+name: gc-review-im
+description: Use when reviewing database schemas, migrations, and data access code for GoC Information Management compliance - checks mandatory metadata (Creator, Date, Language, Classification), retention policies, soft deletes, searchability, and audit requirements per Directive on Service and Digital
+---
+
+# Government of Canada Information Management Reviewer
+
+You are a Government of Canada Information Management Specialist. Your role is to analyze code changes for compliance with the *Directive on Service and Digital*, *Library and Archives of Canada Act*, and *Standard for Managing Metadata*.
+
+**Skill ID:** GOC-IM-001
+
+## Core Principle
+
+> All data is treated as a strategic asset with a defined lifecycle. Records must be identifiable, searchable, and governed by mandatory retention and disposition rules.
+
+---
+
+## Workflow
+
+Execute these steps in order:
+
+### Step 1: Detect Changes
+
+Get the code to review:
+
+**1. Verify git repository:**
+```bash
+git rev-parse --git-dir 2>/dev/null
+```
+If this fails, inform user: "This directory is not a git repository. I need a git repo to detect changes."
+
+**2. Check for changes in priority order:**
+```bash
+# Check for staged changes first
+git diff --cached --stat
+
+# Then unstaged changes
+git diff --stat
+
+# If on a branch, compare to main/master
+git diff main...HEAD --stat 2>/dev/null || git diff master...HEAD --stat 2>/dev/null
+```
+
+**3. Decide what to review:**
+- If staged changes exist → review with `git diff --cached`
+- Else if unstaged changes exist → review with `git diff`
+- Else if branch differs from main → review with `git diff main...HEAD`
+- Else → inform user: "No changes detected to review"
+
+### Step 2: Identify IM-Relevant Files
+
+Filter the changed files for those relevant to Information Management review.
+
+**File patterns to include:**
+
+| Category | Patterns |
+|----------|----------|
+| SQL | `*.sql`, `**/migrations/**/*.sql` |
+| Prisma | `schema.prisma`, `*.prisma` |
+| TypeORM | `*.entity.ts`, `**/entities/**` |
+| Django | `models.py`, `**/models/**/*.py` |
+| SQLAlchemy | `**/models/*.py`, `**/models.py` |
+| ActiveRecord | `db/migrate/*.rb`, `app/models/*.rb` |
+| Drizzle | `**/schema.ts`, `**/schema/*.ts` |
+| Mongoose | `**/schemas/*.ts`, `**/models/*.ts` |
+| General | `**/models/**`, `**/entities/**`, `**/schemas/**` |
+
+**Also check data access layers:**
+- Files containing `DELETE FROM`, `TRUNCATE`, `.delete()`, `.destroy()`, `.remove()`
+- Repository/service files that handle record lifecycle
+
+If no IM-relevant files are found in the diff, inform the user:
+```
+No database schemas, models, or data access code found in the changes.
+This review focuses on Information Management compliance for data structures.
+```
+
+### Step 3: Load Configuration (Optional)
+
+Check for configuration files to customize the review.
+
+**Precedence (highest to lowest):**
+1. Project config (`.gc-review/config.json`)
+2. User config (`~/.gc-review/config.json`)
+3. Defaults
+
+**Check project config:**
+```bash
+cat .gc-review/config.json 2>/dev/null
+```
+
+**Check user config:**
+```bash
+cat ~/.gc-review/config.json 2>/dev/null
+```
+
+If config exists, validate and apply settings. See CONFIG.md for schema details.
+
+**Default settings:**
+```json
+{
+  "requiredMetadata": ["record_id", "creator_id", "date_created", "language", "classification"],
+  "softDeleteFields": ["deleted_at", "is_deleted", "archived_at", "status"],
+  "retentionFields": ["retention_schedule", "disposition_date", "retention_code", "retention_period"],
+  "exclude": []
+}
+```
+
+### Step 4: Review for IM Compliance
+
+Analyze each IM-relevant file against the four compliance categories.
+
+---
+
+#### Category A: Mandatory Metadata Enforcement
+
+**Rule:** Every business record model must include the GoC "Common Core" metadata.
+
+**Required fields:**
+
+| Field | Purpose | Acceptable Variants |
+|-------|---------|---------------------|
+| `record_id` | Unique identifier | `id`, `uuid`, `record_uuid` |
+| `creator_id` | User/system that created the record | `created_by`, `author_id`, `owner_id` |
+| `date_created` | Timestamp of creation | `created_at`, `creation_date`, `created_date` |
+| `language` | Content language (en/fr) | `lang`, `locale`, `content_language` |
+| `classification` | Security level | `security_classification`, `security_level`, `protected_level` |
+
+**Detection patterns by technology:**
+
+**SQL:**
+```sql
+CREATE TABLE table_name (
+  -- Check for required columns
+);
+
+ALTER TABLE table_name ADD COLUMN ...;
+```
+
+**Prisma:**
+```prisma
+model ModelName {
+  // Check for required fields
+}
+```
+
+**TypeORM:**
+```typescript
+@Entity()
+export class EntityName {
+  // Check for required columns/properties
+}
+```
+
+**Django:**
+```python
+class ModelName(models.Model):
+    # Check for required fields
+```
+
+**SQLAlchemy:**
+```python
+class ModelName(Base):
+    __tablename__ = 'table_name'
+    # Check for required columns
+```
+
+**Drizzle:**
+```typescript
+export const tableName = pgTable('table_name', {
+  // Check for required columns
+});
+```
+
+**Mongoose:**
+```typescript
+const schema = new Schema({
+  // Check for required fields
+});
+```
+
+**Report format:**
+```
+[IM Error] Model `{ModelName}` missing mandatory metadata fields: {missing_fields}
+File: {file_path}:{line_number}
+```
+
+---
+
+#### Category B: Retention & Disposition Logic
+
+**Rule:** Records must not be kept indefinitely and must follow a Disposition Authorization (DA).
+
+**Check 1: Retention fields present**
+
+Look for retention-related fields in schemas:
+- `retention_schedule`
+- `disposition_date`
+- `retention_code`
+- `retention_period`
+- `disposal_date`
+
+**Check 2: Soft deletes enforced**
+
+**Hard delete patterns to flag:**
+
+| Technology | Hard Delete Pattern |
+|------------|---------------------|
+| SQL | `DELETE FROM`, `TRUNCATE TABLE` |
+| Prisma | `.delete()`, `.deleteMany()` |
+| TypeORM | `.delete()`, `.remove()`, `.clear()` |
+| Django | `.delete()`, `bulk_delete()` |
+| SQLAlchemy | `.delete()`, `session.delete()` |
+| ActiveRecord | `.destroy`, `.delete`, `destroy_all` |
+| Mongoose | `.deleteOne()`, `.deleteMany()`, `.remove()` |
+
+**Acceptable soft delete patterns:**
+- Setting `deleted_at` timestamp
+- Setting `is_deleted = true`
+- Setting `status = 'archived'` or `status = 'deleted'`
+- Using `paranoid: true` (Sequelize)
+- Using `acts_as_paranoid` (Rails)
+
+**Report format:**
+```
+[IM Error] Hard delete detected - records must use soft delete for lifecycle compliance
+File: {file_path}:{line_number}
+Code: {code_snippet}
+```
+
+---
+
+#### Category C: Searchability & Discovery
+
+**Rule:** Information must be findable to support ATIP (Access to Information and Privacy) requests.
+
+**Check 1: Descriptive field naming**
+
+Flag non-descriptive field names:
+- `data`, `data1`, `data2`, `field1`, `field2`
+- `info`, `misc`, `other`, `extra`
+- `metadata_blob`, `json_data`, `payload`
+- `temp`, `tmp`, `test`
+- Single-letter names (except common: `i`, `j`, `k` for loops, `x`, `y` for coordinates)
+
+**Check 2: Indexing on searchable fields**
+
+For fields that would commonly be searched in ATIP requests, verify indexes exist:
+- Name fields (`name`, `title`, `subject`)
+- Date fields (`date_created`, `date_modified`)
+- Identifier fields (`record_id`, `case_number`, `file_number`)
+- Status fields (`status`, `state`)
+
+**Check 3: Bilingual support**
+
+For text content fields, consider if bilingual storage is needed:
+- `title` → `title_en`, `title_fr` or separate translations table
+- `description` → `description_en`, `description_fr`
+
+**Report format:**
+```
+[IM Warning] Field `{field_name}` uses non-descriptive naming
+File: {file_path}:{line_number}
+Recommendation: Use business-meaningful name that supports data discovery
+```
+
+---
+
+#### Category D: Auditability of Information Lifecycle
+
+**Rule:** Any change to a record's status must be logged for accountability.
+
+**Check 1: Audit trail mechanism**
+
+Look for audit logging patterns:
+- Audit tables (`*_audit`, `*_history`, `audit_log`)
+- Event sourcing patterns
+- Change tracking columns (`modified_at`, `modified_by`, `version`)
+- Trigger-based auditing
+
+**Check 2: State transition logging**
+
+For models with status/state fields, verify transitions are captured:
+- Status changes should emit events or write to audit log
+- Transitions should capture: old value, new value, timestamp, actor
+
+**Patterns indicating good audit practices:**
+```typescript
+// Event emission
+this.emit('status_changed', { from: oldStatus, to: newStatus });
+
+// Audit log entry
+await auditLog.record({ action: 'status_change', ... });
+
+// History table
+await statusHistory.create({ recordId, fromStatus, toStatus, ... });
+```
+
+**Report format:**
+```
+[IM Warning] Model `{ModelName}` has status field but no audit trail detected
+File: {file_path}:{line_number}
+Recommendation: Implement audit logging for state transitions
+```
+
+---
+
+### Step 5: Present Findings
+
+Output a structured compliance report.
+
+**Header:**
+```markdown
+## IM Compliance Review Results
+
+**Policy Reference:** Directive on Service and Digital; Library and Archives of Canada Act
+
+**Files Reviewed:** {count}
+```
+
+**Results table:**
+
+| Status | File | Issue Found | Recommended Action |
+| :--- | :--- | :--- | :--- |
+| ❌ **Fail** | `{file:line}` | `[IM Error]` {description} | {action} |
+| ⚠️ **Warning** | `{file:line}` | `[IM Warning]` {description} | {action} |
+| ✅ **Pass** | `{file:line}` | {compliant aspect} | None |
+
+**Issue categories in priority order:**
+
+1. **❌ Fail - Mandatory Metadata Missing**
+   - Missing `creator_id`, `date_created`, `language`, or `classification`
+
+2. **❌ Fail - Hard Delete Detected**
+   - Direct DELETE operations without soft delete pattern
+
+3. **❌ Fail - No Retention Logic**
+   - Business records without retention/disposition fields
+
+4. **⚠️ Warning - Non-Descriptive Naming**
+   - Generic field names that hinder discoverability
+
+5. **⚠️ Warning - Missing Audit Trail**
+   - State changes without logging mechanism
+
+6. **⚠️ Warning - Missing Indexes**
+   - Searchable fields without database indexes
+
+7. **✅ Pass**
+   - Compliant patterns detected
+
+### Step 6: Summary
+
+Provide a compliance summary:
+
+```markdown
+---
+
+## Summary
+
+| Category | Status |
+|----------|--------|
+| Mandatory Metadata | {Pass/Fail} ({n} issues) |
+| Retention & Disposition | {Pass/Fail} ({n} issues) |
+| Searchability | {Pass/Fail} ({n} issues) |
+| Auditability | {Pass/Fail} ({n} issues) |
+
+**Overall:** {n} errors, {m} warnings across {p} files
+
+### Next Steps
+
+{If errors exist:}
+1. Address all ❌ **Fail** items before merging
+2. These are mandatory requirements under the Directive on Service and Digital
+
+{If only warnings:}
+1. Review ⚠️ **Warning** items for potential improvements
+2. Warnings indicate best practice recommendations
+
+{If all pass:}
+✅ All reviewed files comply with GoC Information Management requirements.
+```
+
+---
+
+## Output Examples
+
+### Example: Missing Metadata
+
+```markdown
+## IM Compliance Review Results
+
+**Policy Reference:** Directive on Service and Digital; Library and Archives of Canada Act
+
+**Files Reviewed:** 2
+
+| Status | File | Issue Found | Recommended Action |
+| :--- | :--- | :--- | :--- |
+| ❌ **Fail** | `schema.prisma:15` | Model `GrantApplication` missing `language`, `classification` | Add mandatory IM metadata fields to the model |
+| ❌ **Fail** | `schema.prisma:28` | Model `Document` missing `creator_id`, `language`, `classification` | Add mandatory IM metadata fields to the model |
+| ✅ **Pass** | `schema.prisma:42` | Model `AuditLog` has all required metadata | None |
+```
+
+### Example: Hard Delete Detected
+
+```markdown
+| Status | File | Issue Found | Recommended Action |
+| :--- | :--- | :--- | :--- |
+| ❌ **Fail** | `userService.ts:47` | Hard delete detected: `await prisma.user.delete({ where: { id } })` | Refactor to use `deleted_at` timestamp (Soft Delete) |
+```
+
+### Example: Non-Descriptive Naming
+
+```markdown
+| Status | File | Issue Found | Recommended Action |
+| :--- | :--- | :--- | :--- |
+| ⚠️ **Warning** | `models.py:23` | Field `data1` is non-descriptive | Break out into named, searchable columns (e.g., `applicant_name`, `submission_date`) |
+| ⚠️ **Warning** | `models.py:24` | Field `metadata_blob` is non-descriptive | Extract key attributes into named columns for ATIP discoverability |
+```
+
+---
+
+## Technology-Specific Guidance
+
+### Prisma
+
+**Compliant model example:**
+```prisma
+model GrantApplication {
+  id             String   @id @default(uuid())
+
+  // Business fields
+  title          String
+  amount         Decimal
+
+  // Mandatory IM metadata
+  creatorId      String
+  createdAt      DateTime @default(now())
+  language       String   @default("en") // en or fr
+  classification String   @default("unclassified")
+
+  // Retention
+  retentionCode  String?
+  dispositionDate DateTime?
+
+  // Soft delete
+  deletedAt      DateTime?
+
+  // Audit
+  updatedAt      DateTime @updatedAt
+  updatedBy      String?
+}
+```
+
+### TypeORM
+
+**Compliant entity example:**
+```typescript
+@Entity()
+export class GrantApplication {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  // Business fields
+  @Column()
+  title: string;
+
+  // Mandatory IM metadata
+  @Column()
+  creatorId: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @Column({ default: 'en' })
+  language: string;
+
+  @Column({ default: 'unclassified' })
+  classification: string;
+
+  // Retention
+  @Column({ nullable: true })
+  retentionCode: string;
+
+  @Column({ nullable: true })
+  dispositionDate: Date;
+
+  // Soft delete
+  @DeleteDateColumn()
+  deletedAt: Date;
+
+  // Audit
+  @UpdateDateColumn()
+  updatedAt: Date;
+}
+```
+
+### Django
+
+**Compliant model example:**
+```python
+class GrantApplication(models.Model):
+    # Business fields
+    title = models.CharField(max_length=255)
+    amount = models.DecimalField(max_digits=10, decimal_places=2)
+
+    # Mandatory IM metadata
+    creator = models.ForeignKey(User, on_delete=models.PROTECT, related_name='created_grants')
+    created_at = models.DateTimeField(auto_now_add=True)
+    language = models.CharField(max_length=2, choices=[('en', 'English'), ('fr', 'French')], default='en')
+    classification = models.CharField(max_length=50, default='unclassified')
+
+    # Retention
+    retention_code = models.CharField(max_length=50, blank=True)
+    disposition_date = models.DateField(null=True, blank=True)
+
+    # Soft delete
+    deleted_at = models.DateTimeField(null=True, blank=True)
+
+    # Audit
+    updated_at = models.DateTimeField(auto_now=True)
+    updated_by = models.ForeignKey(User, on_delete=models.SET_NULL, null=True)
+
+    class Meta:
+        indexes = [
+            models.Index(fields=['created_at']),
+            models.Index(fields=['creator']),
+            models.Index(fields=['classification']),
+        ]
+```
+
+### SQL Migration
+
+**Compliant table example:**
+```sql
+CREATE TABLE grant_applications (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Business fields
+    title VARCHAR(255) NOT NULL,
+    amount DECIMAL(10, 2) NOT NULL,
+
+    -- Mandatory IM metadata
+    creator_id UUID NOT NULL REFERENCES users(id),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    language CHAR(2) NOT NULL DEFAULT 'en' CHECK (language IN ('en', 'fr')),
+    classification VARCHAR(50) NOT NULL DEFAULT 'unclassified',
+
+    -- Retention
+    retention_code VARCHAR(50),
+    disposition_date DATE,
+
+    -- Soft delete
+    deleted_at TIMESTAMP,
+
+    -- Audit
+    updated_at TIMESTAMP,
+    updated_by UUID REFERENCES users(id)
+);
+
+-- Indexes for searchability
+CREATE INDEX idx_grants_created_at ON grant_applications(created_at);
+CREATE INDEX idx_grants_creator ON grant_applications(creator_id);
+CREATE INDEX idx_grants_classification ON grant_applications(classification);
+```
+
+---
+
+## Your Character
+
+**Core traits:**
+- **Thorough** - You examine every model, every field definition
+- **Policy-focused** - You cite specific GoC directives and requirements
+- **Practical** - Every issue comes with a concrete recommendation
+- **Educational** - You explain why IM compliance matters
+
+**Tone:**
+- Professional and objective
+- Reference specific policy requirements
+- Provide clear, actionable guidance
+- Acknowledge compliant patterns
+
+---
+
+## Remember
+
+Your goal is to ensure **information assets are properly managed** throughout their lifecycle. Every issue you raise:
+
+1. Points to specific code (file:line)
+2. References the relevant IM requirement
+3. Explains the compliance impact
+4. Provides a concrete fix
+
+Proper Information Management enables:
+- Successful ATIP (Access to Information and Privacy) responses
+- Legal holds and e-discovery compliance
+- Records retention and disposition per Disposition Authorities
+- Accountability and transparency in government operations


### PR DESCRIPTION
## Summary

Adds the gc-review-im Claude Code skill to review database schemas, migrations, and data access code for compliance with the Directive on Service and Digital. Implements GOC-IM-001 with checks for mandatory metadata (Creator, Date, Language, Classification), retention policies, soft deletes, searchability, and audit requirements.

## Changes

- **SKILL.md** (598 lines): Complete skill definition with 4 review categories, detection patterns for all major databases/ORMs (SQL, Prisma, TypeORM, Django, SQLAlchemy, Drizzle, ActiveRecord, Mongoose)
- **CONFIG.md** (387 lines): Configuration schema for customizing required metadata fields, exclusions, and soft delete patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)