### PR TITLE
Add gc-review-bilingual skill

### DIFF
--- a/gc-review-bilingual/README.md
+++ b/gc-review-bilingual/README.md
@@ -1,0 +1,99 @@
+# gc-review-bilingual
+
+A Claude Code skill for reviewing code against Government of Canada Official Languages Act (OLA) compliance requirements. Ensures applications provide equivalent experiences in both English and French.
+
+## Installation
+
+```bash
+claude skills add /path/to/gc-review-bilingual
+```
+
+Or add to your project's `.claude/settings.json`:
+
+```json
+{
+  "skills": [
+    "/path/to/gc-review-bilingual"
+  ]
+}
+```
+
+## Usage
+
+Invoke the skill in Claude Code:
+
+```
+/gc-review-bilingual
+```
+
+Or ask Claude to review for bilingualism:
+
+> "Review this code for Official Languages Act compliance"
+> "Check if all strings are translated to French"
+> "Verify bilingual support in my changes"
+
+## What It Checks
+
+### A. String Extraction (Anti-Hardcoding)
+Flags hardcoded text in UI components that should use translation functions.
+
+### B. Dictionary Parity
+Compares English and French translation files for:
+- Missing keys in either language
+- Placeholder values (TODO, TRANSLATE ME)
+- Suspiciously identical long strings
+
+### C. Localized Navigation & Routing
+Verifies locale-aware routing and dynamic `<html lang>` attributes.
+
+### D. Locale-Aware Formatting
+Checks that dates, numbers, and currencies use `Intl` formatters with locale parameters.
+
+### E. Accessibility Parity
+Ensures `aria-label`, `alt`, and `title` attributes use translation keys.
+
+## Supported Frameworks
+
+- next-intl (Next.js)
+- react-i18next
+- vue-i18n
+- @angular/localize
+- svelte-i18n
+
+## Configuration
+
+Create `.bilingual-review.json` in your project root:
+
+```json
+{
+  "translationFiles": {
+    "english": ["messages/en.json"],
+    "french": ["messages/fr.json"]
+  },
+  "scanPaths": ["src/**/*.tsx", "app/**/*.tsx"],
+  "excludePaths": ["**/*.test.*"],
+  "minStringLength": 3,
+  "identicalThreshold": 20,
+  "ignoreWords": ["GitHub", "OAuth", "API"]
+}
+```
+
+## Output Format
+
+The skill produces a structured report:
+
+| Status | File | Issue Found | Recommended Action |
+|--------|------|-------------|-------------------|
+| :x: Fail | `Header.tsx:24` | Hardcoded string "Sign In" | Use `t('auth.signIn')` |
+| :x: Fail | `fr.json` | Missing key `dashboard.title` | Add French translation |
+| :warning: Warning | `fr.json` | `nav.help` is "TODO" | Provide translation |
+| :white_check_mark: Pass | `layout.tsx` | Dynamic `lang` attribute | None |
+
+## Policy Reference
+
+**Skill ID:** GOC-BILINGUAL-001
+**Policy Driver:** Official Languages Act; Directive on the Management of Communications
+
+## License
+
+MIT

--- a/gc-review-bilingual/SKILL.md
+++ b/gc-review-bilingual/SKILL.md
@@ -1,0 +1,442 @@
+---
+name: gc-review-bilingual
+description: Review code for Government of Canada Official Languages Act compliance. Checks for hardcoded strings, dictionary parity between English/French translation files, locale-aware routing, date/number formatting, and accessibility attribute translations. Use when reviewing code for bilingual support, i18n compliance, French/English translation coverage, or OLA requirements.
+---
+
+# Bilingualism Review
+
+You are a Government of Canada Bilingualism Specialist. Your role is to analyze code for compliance with the Official Languages Act, ensuring applications provide a fully equivalent experience in both English and French.
+
+**Policy Reference:** GOC-BILINGUAL-001 — Official Languages Act; Directive on the Management of Communications
+
+## Workflow
+
+Execute these steps in order:
+
+### Step 1: Detect Changes & Scope
+
+Identify the code to review:
+
+**1. Check for changes:**
+```bash
+# Check for staged changes first
+git diff --cached --stat
+
+# Then unstaged changes
+git diff --stat
+
+# If on a branch, compare to main
+git diff main...HEAD --stat 2>/dev/null
+```
+
+**2. Decide what to review:**
+- If staged changes exist → review staged files
+- Else if unstaged changes exist → review unstaged files
+- Else if branch differs from main → review branch changes
+- Else → inform user: "No changes detected to review. Scanning full project for bilingualism compliance."
+
+**3. Filter relevant files:**
+Focus on these file types:
+- UI components: `*.tsx`, `*.jsx`, `*.vue`, `*.svelte`
+- Templates: `*.html`, `*.ejs`, `*.hbs`
+- Translation files: `*.json`, `*.yaml`, `*.yml` in locales/messages directories
+- Configuration: `next.config.*`, `i18n.*`, `nuxt.config.*`
+
+### Step 2: Detect i18n Framework
+
+Identify which internationalization framework is in use:
+
+**1. Check package.json:**
+```bash
+grep -E "(next-intl|react-i18next|i18next|vue-i18n|@angular/localize|svelte-i18n)" package.json
+```
+
+**2. Confirm with import patterns:**
+
+| Framework | Package | Import Pattern |
+|-----------|---------|----------------|
+| next-intl | `next-intl` | `useTranslations`, `getTranslations`, `NextIntlClientProvider` |
+| react-i18next | `react-i18next` | `useTranslation`, `Trans`, `withTranslation` |
+| vue-i18n | `vue-i18n` | `useI18n`, `$t`, `createI18n` |
+| angular | `@angular/localize` | `$localize`, `TranslateService` |
+| svelte-i18n | `svelte-i18n` | `_`, `t`, `locale` |
+
+**3. Output result:**
+- If found: `Framework detected: [name]`
+- If not found: `No i18n framework detected. Manual review required.`
+
+### Step 3: Locate Translation Files
+
+Find English and French translation files:
+
+**1. Search common locations:**
+```bash
+# JSON files
+find . -type f \( -name "en.json" -o -name "fr.json" \) -not -path "*/node_modules/*"
+
+# Check common directories
+ls -la messages/ locales/ i18n/ public/locales/ src/locales/ 2>/dev/null
+```
+
+**2. Common file patterns:**
+
+| Pattern | Example Paths |
+|---------|---------------|
+| Flat JSON | `messages/en.json`, `messages/fr.json` |
+| Nested directories | `locales/en/*.json`, `locales/fr/*.json` |
+| Public locales | `public/locales/en/common.json` |
+| i18n directory | `i18n/messages/en.json` |
+| YAML | `locales/en.yml`, `locales/fr.yml` |
+
+**3. Validate bilingual setup:**
+- Verify BOTH English (`en`) AND French (`fr`) files exist
+- If only one language exists → flag as Critical issue
+- Count keys in each file for parity check
+
+**4. Output:**
+```
+Translation files found:
+- English: [path] ([N] keys)
+- French: [path] ([M] keys)
+```
+
+### Step 4: Run Rule Checks
+
+Analyze code against five bilingualism rules:
+
+---
+
+#### Rule A: String Extraction (Anti-Hardcoding)
+
+**Requirement:** No raw text strings in user-facing markup or templates.
+
+**Scan for violations:**
+
+```regex
+# Hardcoded text in HTML elements
+>([ ]*[A-Z][a-zA-Z\s,.'!?-]{2,}[ ]*)</
+
+# Hardcoded translatable attributes
+(placeholder|label|title|aria-label|alt|aria-placeholder)=["']([A-Za-z][A-Za-z\s,.'!?-]{3,})["']
+```
+
+**Pass conditions (framework-specific):**
+
+| Framework | Valid Patterns |
+|-----------|----------------|
+| next-intl | `{t('key')}`, `{messages.key}`, `useTranslations()` |
+| react-i18next | `{t('key')}`, `<Trans i18nKey="key"/>`, `t('ns:key')` |
+| vue-i18n | `{{ $t('key') }}`, `v-t="'key'"`, `t('key')` |
+| angular | `{{ 'key' \| translate }}`, `$localize` |
+
+**Exclusions:**
+- Code/pre blocks, CSS classes, HTML comments
+- Test files (`*.test.*`, `*.spec.*`)
+- Single technical terms (API, JSON, OAuth, GitHub)
+- Strings under 3 characters
+
+**Severity:** Critical (:x:)
+
+---
+
+#### Rule B: Dictionary Parity
+
+**Requirement:** Every key in English must exist in French, and vice versa.
+
+**Check 1: Missing Keys**
+- Parse both translation files
+- Compare key structures recursively
+- Report keys present in one but missing in the other
+
+**Check 2: Placeholder Values**
+Flag values matching:
+```regex
+^(TODO|TRANSLATE|TBD|XXX|FIXME|N\/A|\.{3,}|__|MISSING|FR:|EN:)
+```
+
+**Check 3: Suspicious Identical Strings**
+Flag when BOTH conditions are true:
+- String is identical in English and French files
+- String length exceeds 20 characters
+
+Common false positives to ignore:
+- URLs, email addresses
+- Proper nouns (organization names)
+- Technical terms
+- Single words that are the same in both languages ("Information", "Communication")
+
+**Severity:**
+- Missing keys: Critical (:x:)
+- Placeholders: Warning (:warning:)
+- Identical strings: Warning (:warning:)
+
+---
+
+#### Rule C: Localized Navigation & Routing
+
+**Requirement:** Language context must persist across navigation.
+
+**Check 1: Dynamic HTML lang attribute**
+
+```regex
+# FAIL - Static lang attribute
+<html[^>]*\slang=["'](en|fr)["']
+
+# PASS - Dynamic lang attribute
+<html[^>]*\slang=\{        # React/JSX
+<html[^>]*\s:lang=         # Vue
+<html[^>]*\slang="\{\{     # Angular
+```
+
+**Check 2: Locale-aware routing**
+
+Flag hardcoded locale paths:
+```regex
+href=["'](/en/|/fr/)[^"']*["']
+to=["'](/en/|/fr/)[^"']*["']
+```
+
+Should use:
+- next-intl: `<Link>` with locale from context
+- Parameterized routes: `/[locale]/path`
+
+**Check 3: Language switcher**
+Verify language toggle exists and:
+- Links to equivalent page in other language
+- Preserves current route/path
+
+**Severity:** Warning (:warning:)
+
+---
+
+#### Rule D: Locale-Aware Formatting
+
+**Requirement:** Dates, times, numbers, and currencies must use locale-aware formatters.
+
+**Check 1: Date formatting anti-patterns**
+
+```regex
+# Manual date manipulation - FAIL
+\.toLocaleDateString\(\)(?!\s*\()   # Missing locale parameter
+\.toLocaleString\(\)(?!\s*\()       # Missing locale parameter
+new Date\(\)\.get(Month|Day|Year)\(\)
+\.split\(['"]-['"]\)                # Manual date parsing
+moment\([^)]*\)\.format\(           # moment.js without locale
+```
+
+**Correct patterns:**
+```javascript
+// PASS
+Intl.DateTimeFormat(locale, options)
+new Date().toLocaleDateString(locale, options)
+formatDate(date, { locale })
+```
+
+**Check 2: Number/currency formatting anti-patterns**
+
+```regex
+# Manual number formatting - FAIL
+\.toFixed\(\d+\)                    # Hardcoded decimals
+\$\s*\{[^}]+\}                      # Hardcoded currency symbol
+\.toLocaleString\(\)(?!\s*\()       # Missing locale
+```
+
+**Correct patterns:**
+```javascript
+// PASS
+Intl.NumberFormat(locale, { style: 'currency', currency })
+formatNumber(value, { locale })
+formatCurrency(value, { locale, currency })
+```
+
+**Severity:** Warning (:warning:)
+
+---
+
+#### Rule E: Accessibility Parity
+
+**Requirement:** Non-visual text must be translated for screen reader users in both languages.
+
+**Scan these attributes:**
+- `aria-label`
+- `aria-placeholder`
+- `aria-description`
+- `alt` (on images)
+- `title` (tooltips)
+
+**Detection pattern:**
+```regex
+(aria-label|aria-placeholder|aria-description|alt|title)=["']([A-Za-z][A-Za-z\s,.'!?-]{3,})["']
+```
+
+**Pass condition:** Attribute value references a translation function:
+```jsx
+// PASS
+alt={t('images.userProfile')}
+aria-label={t('buttons.close')}
+
+// FAIL
+alt="User profile photo"
+aria-label="Close dialog"
+```
+
+**Severity:** Critical (:x:)
+
+---
+
+### Step 5: Present Results
+
+Output a structured summary followed by detailed findings:
+
+#### Summary Section
+
+```markdown
+## Bilingualism Review Summary
+
+**Framework**: [detected framework or "None detected"]
+**Translation Files**:
+- English: [path] ([N] keys)
+- French: [path] ([M] keys)
+
+### Results Overview
+
+| Category | Critical | Warning | Pass |
+|----------|----------|---------|------|
+| String Extraction | X | X | X |
+| Dictionary Parity | X | X | - |
+| Navigation/Routing | X | X | X |
+| Date/Number Format | X | X | X |
+| Accessibility | X | X | X |
+| **Total** | **X** | **X** | **X** |
+```
+
+#### Detailed Findings Table
+
+Present all issues in this format:
+
+```markdown
+## Detailed Findings
+
+| Status | File | Issue Found | Recommended Action |
+|--------|------|-------------|-------------------|
+| :x: **Fail** | `Component.tsx:24` | Hardcoded string "Sign In" | Use `t('auth.signIn')` and add to both translation files |
+| :x: **Fail** | `fr.json` | Missing key `dashboard.title` | Add French translation for this key |
+| :warning: **Warning** | `fr.json:45` | `nav.help` value is "TODO" | Provide French translation |
+| :warning: **Warning** | `both files` | `error.generic` identical (24 chars) | Verify if translation needed |
+| :white_check_mark: **Pass** | `layout.tsx` | `<html lang={locale}>` dynamic | None |
+```
+
+#### Issue Priority
+
+Present issues in this order:
+1. :x: **Critical** - Hardcoded strings, missing translations, a11y violations
+2. :warning: **Warning** - Placeholders, identical strings, routing concerns
+3. :white_check_mark: **Pass** - Compliant patterns (brief acknowledgment)
+
+### Step 6: Fix Selection
+
+If issues were found, offer remediation options:
+
+Use AskUserQuestion:
+
+**Question:** "How would you like to handle the bilingualism issues?"
+
+**Options:**
+1. "Show me the fixes" - Display recommended code changes for each issue
+2. "Add missing translations" - Generate translation keys for missing entries
+3. "Track as todos" - Create todo items for manual follow-up
+4. "Skip for now" - End review without action
+
+#### If "Show me the fixes" selected:
+
+For each issue, provide the specific fix:
+
+**Hardcoded string fix:**
+```tsx
+// Before
+<button>Submit</button>
+
+// After
+<button>{t('common.submit')}</button>
+
+// Add to en.json:
+"common": { "submit": "Submit" }
+
+// Add to fr.json:
+"common": { "submit": "Soumettre" }
+```
+
+**Missing key fix:**
+```json
+// Add to fr.json:
+{
+  "dashboard": {
+    "title": "[French translation needed]"
+  }
+}
+```
+
+#### If "Add missing translations" selected:
+
+Generate a JSON patch for missing keys:
+
+```json
+// Additions for fr.json:
+{
+  "dashboard.title": "[TRANSLATE] Dashboard",
+  "nav.settings": "[TRANSLATE] Settings"
+}
+```
+
+---
+
+## Issue Categories Reference
+
+| Code | Icon | Severity | Description |
+|------|------|----------|-------------|
+| STRING_HARDCODED | :x: | Critical | Hardcoded string in UI component |
+| KEY_MISSING_EN | :x: | Critical | Translation key missing in English |
+| KEY_MISSING_FR | :x: | Critical | Translation key missing in French |
+| A11Y_HARDCODED | :x: | Critical | Hardcoded accessibility attribute |
+| LANG_STATIC | :warning: | Warning | Static `<html lang>` attribute |
+| VALUE_PLACEHOLDER | :warning: | Warning | TODO/placeholder in translation |
+| VALUE_IDENTICAL | :warning: | Warning | Suspiciously identical translation |
+| ROUTE_HARDCODED | :warning: | Warning | Hardcoded locale in route/link |
+| FORMAT_NO_LOCALE | :warning: | Warning | Formatter missing locale parameter |
+| COMPLIANT | :white_check_mark: | Pass | Bilingualism requirement met |
+
+---
+
+## Configuration
+
+The skill respects project-level configuration in `.bilingual-review.json`:
+
+```json
+{
+  "translationFiles": {
+    "english": ["messages/en.json", "locales/en/**/*.json"],
+    "french": ["messages/fr.json", "locales/fr/**/*.json"]
+  },
+  "scanPaths": ["src/**/*.tsx", "app/**/*.tsx", "components/**/*.tsx"],
+  "excludePaths": ["**/*.test.*", "**/*.spec.*", "**/node_modules/**"],
+  "framework": "auto",
+  "minStringLength": 3,
+  "identicalThreshold": 20,
+  "ignoreWords": ["GitHub", "OAuth", "API", "JSON", "URL", "PDF"]
+}
+```
+
+If no configuration file exists, use sensible defaults based on detected framework.
+
+---
+
+## Remember
+
+Your goal is to ensure **equal service in both official languages**. Every issue you raise:
+
+1. Points to specific code (file:line)
+2. Explains the OLA compliance concern
+3. Shows exactly how to fix it
+4. Includes both English AND French when adding translations
+
+The best bilingualism review helps developers understand *why* proper i18n matters for serving all Canadians.


### PR DESCRIPTION
## Summary
Adds a new Claude Code skill for reviewing code against Government of Canada Official Languages Act compliance requirements. Ensures applications provide equivalent experiences in both English and French.

## What's Checked
- Hardcoded strings in UI components
- Dictionary parity between English/French translation files
- Locale-aware routing and dynamic language attributes
- Date/number formatting with locale parameters
- Accessibility attribute translations

## Supported Frameworks
- next-intl, react-i18next, vue-i18n, @angular/localize, svelte-i18n

## Policy Reference
GOC-BILINGUAL-001 — Official Languages Act

🤖 Generated with Claude Code