### PR TITLE
Add .claude-plugin directory with plugin metadata

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,37 @@
+{
+  "name": "gc-code-skills",
+  "owner": {
+    "name": "Doug Keefe",
+    "email": "doug@keefe.co"
+  },
+  "plugins": [
+    {
+      "name": "gc-code-skills",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/dougkeefe/gc-code-skills.git"
+      },
+      "description": "Claude Code skills for Government of Canada digital standards compliance reviews — accessibility, security, information management, identity & authentication, branding, and bilingual support.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Doug Keefe",
+        "email": "doug@keefe.co"
+      },
+      "homepage": "https://github.com/dougkeefe/gc-code-skills",
+      "repository": "https://github.com/dougkeefe/gc-code-skills",
+      "license": "MIT",
+      "keywords": [
+        "government-of-canada",
+        "compliance",
+        "accessibility",
+        "security",
+        "wcag",
+        "bilingual",
+        "code-review",
+        "branding",
+        "information-management",
+        "identity-authentication"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "gc-code-skills",
+  "description": "Claude Code skills for Government of Canada digital standards compliance reviews — accessibility, security, information management, identity & authentication, branding, and bilingual support.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Doug Keefe",
+    "email": "doug@keefe.co"
+  },
+  "homepage": "https://github.com/dougkeefe/gc-code-skills",
+  "repository": "https://github.com/dougkeefe/gc-code-skills",
+  "license": "MIT",
+  "keywords": [
+    "government-of-canada",
+    "compliance",
+    "accessibility",
+    "security",
+    "wcag",
+    "bilingual",
+    "code-review",
+    "branding",
+    "information-management",
+    "identity-authentication"
+  ]
+}


### PR DESCRIPTION
## Summary
Creates plugin.json and marketplace.json files in a new .claude-plugin/ directory to enable distribution of GC Code Skills as a Claude Code plugin. This follows the standard plugin manifest format used by similar projects.

## Changes
- Added .claude-plugin/plugin.json with core metadata (name, version, author, keywords)
- Added .claude-plugin/marketplace.json with distribution/source information

## Verification
Both JSON files are valid and conform to the plugin manifest specification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)