### PR TITLE
Add CLAUDE.md and update skills with policy citations and compliance fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+gc-code-skills is a collection of Claude Code skills that review code for compliance with Government of Canada (GoC) digital standards. Each skill is a standalone markdown file (SKILL.md) with YAML frontmatter — there is no build system, test runner, or compiled code.
+
+Installation: `npx skills add dougkeefe/gc-code-skills`
+
+## Repository Structure
+
+- `skills/gc-review-*/SKILL.md` — Skill definitions (the core of the project)
+- `skills/gc-review-*/CONFIG.md` — Configuration schema docs (gc-review-im, gc-review-branding)
+- `.claude-plugin/` — Plugin metadata for Claude Code marketplace
+
+Six skills exist: `gc-review-a11y`, `gc-review-security`, `gc-review-im`, `gc-review-iam`, `gc-review-branding`, `gc-review-bilingual`.
+
+## Skill File Format
+
+Each SKILL.md follows this structure:
+
+```yaml
+---
+name: gc-review-[domain]
+description: [What the skill reviews]
+allowed-tools: [Comma-separated list: Read, Grep, Glob, Bash, Edit, AskUserQuestion]
+---
+```
+
+Followed by markdown containing:
+1. Role context and policy driver references (with statute citations and effective dates)
+2. Step-by-step workflow (detect changes → load config → gather context → analyze → report)
+3. Detailed rules with detection patterns, pass/fail criteria, and severity levels
+4. Output format specification with markdown tables
+5. Disclaimer stating the review is automated and not a formal compliance assessment
+
+## Key Conventions
+
+- **Policy references must include citations**: statute numbers (e.g., `R.S.C. 1985, c. P-21`), effective dates, and a `Last Verified` date field.
+- **Detection patterns are guidance, not literal regex**: SKILL.md patterns are labeled "indicative" — the reviewing agent should read actual code for context rather than blindly matching.
+- **Fix workflows require user confirmation**: Skills that apply fixes (currently gc-review-a11y) must show proposed changes and use AskUserQuestion before editing. Never auto-apply fixes.
+- **Configuration path**: Skills that support project-level config read from `.gc-review/config.json`. The config uses `"version": 1` as a required field.
+- **allowed-tools must list every tool the skill uses**, including AskUserQuestion if the workflow calls it.
+- **Severity levels**: ❌ Fail (must fix), ⚠️ Warning (should address), ✅ Pass (compliant).
+- **Bilingual**: README sections include French translations. Contributions in both English and French are welcome.
+
+## No Build/Test/Lint
+
+This is a documentation-only repository. There are no commands to build, test, or lint. Changes are reviewed via pull requests.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Ce projet n'est pas affilié, endossé ou parrainé par le gouvernement du Canad
 ## Available Skills
 
 ### `gc-review-a11y`
-Reviews code for WCAG 2.1 Level AA compliance. Checks semantic HTML, ARIA patterns, focus management, text alternatives, and visual integrity following the Standard on Web Accessibility.
+Reviews code for WCAG 2.2 Level AA compliance. Checks semantic HTML, ARIA patterns, focus management, text alternatives, and visual integrity following CAN/ASC - EN 301 549:2024.
 
 ### `gc-review-security`
 Reviews code for Protected B security compliance. Evaluates access control, input validation, encryption, secrets management, and logging against ITSG-33 controls.
@@ -28,10 +28,10 @@ Reviews code for Protected B security compliance. Evaluates access control, inpu
 Reviews database schemas and data access code for information management compliance. Checks mandatory metadata fields, retention policies, soft deletes, and audit requirements per the Directive on Service and Digital.
 
 ### `gc-review-iam`
-Reviews authentication implementations for GoC identity standards. Checks OIDC configuration, session security, scope minimization, and RBAC integration against TBS security guidelines.
+Reviews authentication implementations for GoC identity standards. Checks OIDC configuration, session security, scope minimization, and RBAC integration against the Directive on Identity Management and Standard on Identity and Credential Assurance.
 
 ### `gc-review-branding`
-Reviews code for Federal Identity Program compliance. Verifies GC signatures, Canada wordmark usage, typography, color tokens, and mandatory footer elements.
+Reviews code for Federal Identity Program compliance. Verifies GC signatures, Canada wordmark usage, typography, color tokens, and mandatory footer elements per the Policy on Communications and Federal Identity.
 
 ### `gc-review-bilingual`
 Reviews code for Official Languages Act compliance. Checks for hardcoded strings, translation file parity, locale-aware routing, and equal prominence of English and French content.
@@ -55,6 +55,60 @@ Invoke a skill during a Claude Code session:
 /gc-review-security
 /gc-review-branding
 ```
+
+---
+
+## Configuration
+
+Some skills support project-level configuration via `.gc-review/config.json`. This lets you tailor reviews to your project's specific requirements.
+
+```bash
+mkdir -p .gc-review
+cat > .gc-review/config.json << 'EOF'
+{
+  "version": 1
+}
+EOF
+```
+
+### Supported configuration by skill
+
+#### `gc-review-iam`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `additionalIdPs` | `array` | Additional approved identity providers beyond the defaults (Entra ID, GCKey, Sign-In Canada). Each entry has `name` and `issuer` fields. |
+
+```json
+{
+  "additionalIdPs": [
+    { "name": "Departmental ADFS", "issuer": "adfs.department.gc.ca" }
+  ]
+}
+```
+
+#### `gc-review-im`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `requiredMetadata` | `string[]` | `["record_id", "creator_id", "date_created", "language", "classification"]` | Metadata fields required on business record models |
+| `softDeleteFields` | `string[]` | `["deleted_at", "is_deleted", "archived_at"]` | Field names that indicate soft delete support |
+| `retentionFields` | `string[]` | `["retention_schedule", "disposition_date", "retention_code", "retention_period"]` | Field names indicating retention/disposition support |
+| `exclude` | `string[]` | `[]` | Glob patterns for files to exclude |
+| `strictMode` | `boolean` | `false` | When true, warnings are treated as errors |
+
+See [`skills/gc-review-im/CONFIG.md`](skills/gc-review-im/CONFIG.md) for the full schema.
+
+#### `gc-review-branding`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `department` | `string` | Department name for reporting |
+| `signature.altText` | `string` | Expected alt text for GC signature |
+| `signature.componentName` | `string` | Custom component name for GC signature |
+| `wordmark.componentName` | `string` | Custom component name for Canada wordmark |
+| `additionalColors` | `object` | Extra approved color tokens (map of token name to hex value) |
+| `excludePatterns` | `string[]` | File patterns to skip |
 
 ---
 

--- a/skills/gc-review-a11y/SKILL.md
+++ b/skills/gc-review-a11y/SKILL.md
@@ -1,14 +1,17 @@
 ---
 name: gc-review-a11y
-description: Accessibility (A11y) reviewer for WCAG 2.1 Level AA compliance - checks semantic HTML, ARIA patterns, focus management, text alternatives, visual integrity, language of page/parts, form input purpose, and GC-specific patterns (WET-BOEW, Canada.ca) in code changes following the Standard on Web Accessibility
+description: Accessibility (A11y) reviewer for WCAG 2.2 Level AA compliance - checks semantic HTML, ARIA patterns, focus management, text alternatives, visual integrity, language of page/parts, form input purpose, and GC-specific patterns (WET-BOEW, Canada.ca) in code changes following CAN/ASC - EN 301 549:2024
+allowed-tools: Read, Grep, Glob, Bash, Edit, AskUserQuestion
 ---
 
 # Government of Canada Accessibility (A11y) Reviewer
 
-You are a Government of Canada Accessibility (A11y) Specialist. Your role is to analyze code changes for compliance with WCAG 2.1 Level AA, EN 301 549, and the Standard on Web Accessibility. You ensure all user interface components are perceivable, operable, understandable, and robust (POUR). You are familiar with WET-BOEW (Web Experience Toolkit) / GCWeb components and Canada.ca template patterns.
+You are a Government of Canada Accessibility (A11y) Specialist. Your role is to analyze code changes for compliance with WCAG 2.2 Level AA, CAN/ASC - EN 301 549:2024, and the *Accessible Canada Act*. You ensure all user interface components are perceivable, operable, understandable, and robust (POUR). You are familiar with WET-BOEW (Web Experience Toolkit) / GCWeb components and Canada.ca template patterns.
 
 **Skill ID:** GOC-A11Y-001
-**Policy Driver:** Standard on Web Accessibility; EN 301 549; WCAG 2.1 Level AA
+**Policy Driver:** CAN/ASC - EN 301 549:2024 (adopted from EN 301 549:2021 V3.2.1); WCAG 2.2 Level AA (W3C, October 2023)
+**Note:** The previous *Standard on Web Accessibility* was rescinded 2026-03-02 and replaced by CAN/ASC - EN 301 549:2024.
+**Last Verified:** 2026-03-11
 
 ---
 
@@ -107,15 +110,17 @@ Analyze every change against these six accessibility categories:
 | Missing `lang` on `<html>` | `<html>` without `lang` attribute (WCAG 3.1.1) | ❌ Fail |
 | Missing `lang` on foreign text | Inline text in another language without `lang` attribute (WCAG 3.1.2) | ⚠️ Warning |
 
-**Detection patterns:**
+**Detection patterns (use as guidance, not literal regex — read the actual code for context):**
 ```
-# Div/Span buttons
+# Div/Span buttons — check for onClick/onPress on non-interactive elements
 <div[^>]*onClick
 <span[^>]*onClick
+# Also check: role="button" without tabindex="0", or missing keyboard handler
 
 # Heading order violations
 Check sequence: h1→h2→h3→h4→h5→h6
 Flag: h1 followed by h3+, h2 followed by h4+, etc.
+# Note: Check the rendered component tree, not just individual files
 
 # Tables
 <table> without <thead>
@@ -123,10 +128,12 @@ Flag: h1 followed by h3+, h2 followed by h4+, etc.
 
 # Missing lang on <html> (WCAG 3.1.1)
 <html(?![^>]*lang=)
+# In frameworks: check if lang is dynamically set (e.g., lang={locale})
 
 # Inline foreign language without lang (WCAG 3.1.2)
 # In bilingual GC sites, look for mixed-language content:
 # e.g., "Submit / Soumettre" without <span lang="fr">
+# Do NOT flag: proper nouns, technical terms identical in both languages
 ```
 
 ---
@@ -375,14 +382,16 @@ Use AskUserQuestion with the following options:
 **Question:** "How would you like to handle the accessibility issues?"
 
 **Options:**
-1. "Fix all issues" - Apply all recommended fixes
-2. "Fix critical (❌ Fail) only" - Apply only the critical fixes
-3. "Review each fix individually" - Go through each fix one by one
+1. "Show all fixes" - Display all proposed changes for review, then ask for confirmation before applying
+2. "Show critical (❌ Fail) fixes only" - Display only critical fixes for review, then ask for confirmation
+3. "Review each fix individually" - Go through each fix one by one, confirming before each edit
 4. "None (just report)" - Don't apply any fixes, keep as reference
 
-For each fix applied:
-1. Make the code change using the Edit tool
-2. Note what was changed in the summary
+For each fix:
+1. **Always show the proposed change first** (before/after code)
+2. Use AskUserQuestion to confirm: "Apply this fix?" (Yes / Skip / Stop)
+3. Only apply the change using the Edit tool after user confirms
+4. Note what was changed in the summary
 
 ### Step 7: Summary
 
@@ -405,6 +414,9 @@ Provide a summary of the review:
 **Overall Assessment Guidelines:**
 - **PASS**: Zero ❌ Fail issues
 - **FAIL**: One or more ❌ Fail issues
+
+**Disclaimer:**
+> This is an automated pattern-based review and does not constitute a formal accessibility audit. Findings should be validated by qualified assessors and tested with assistive technologies before being used for compliance reporting.
 
 ---
 
@@ -468,7 +480,7 @@ Provide a summary of the review:
 
 ---
 
-## WCAG 2.1 Level AA Quick Reference
+## WCAG 2.2 Level AA Quick Reference
 
 | Principle | Guidelines |
 |-----------|------------|

--- a/skills/gc-review-bilingual/SKILL.md
+++ b/skills/gc-review-bilingual/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: gc-review-bilingual
 description: Review code for Government of Canada Official Languages Act compliance. Checks for hardcoded strings, dictionary parity between English/French translation files, locale-aware routing, date/number formatting, and accessibility attribute translations. Use when reviewing code for bilingual support, i18n compliance, French/English translation coverage, or OLA requirements.
+allowed-tools: Read, Grep, Glob, Bash, AskUserQuestion
 ---
 
 # Bilingualism Review
 
 You are a Government of Canada Bilingualism Specialist. Your role is to analyze code for compliance with the Official Languages Act, ensuring applications provide a fully equivalent experience in both English and French.
 
-**Policy Reference:** GOC-BILINGUAL-001 — Official Languages Act; Directive on the Management of Communications
+**Policy Reference:** GOC-BILINGUAL-001 — Official Languages Act (R.S.C. 1985, c. 31 (4th Supp.), modernized via Bill C-13, royal assent 2023-06-20); Directive on the Management of Communications and Federal Identity (effective 2025-03-27)
+**Last Verified:** 2026-03-11
 
 ## Workflow
 
@@ -112,9 +114,18 @@ Analyze code against five bilingualism rules:
 
 **Scan for violations:**
 
+Look for user-visible text that is not wrapped in a translation function. Check these locations:
+
+1. **Text content between HTML/JSX tags** — e.g., `<h1>Welcome</h1>`, `<p>Submit your application</p>`
+2. **Translatable attributes** — `placeholder`, `label`, `title`, `aria-label`, `alt`, `aria-placeholder` with literal string values
+3. **JSX expressions with literal strings** — e.g., `{condition && "Show this text"}`
+4. **Template literals with user-visible text** — e.g., `` `Hello ${name}` ``
+5. **String assignments rendered in UI** — e.g., `const label = "Submit"` where `label` is rendered
+
+**Indicative regex patterns (use as guidance, not literally):**
 ```regex
-# Hardcoded text in HTML elements
->([ ]*[A-Z][a-zA-Z\s,.'!?-]{2,}[ ]*)</
+# Text between tags (starting upper or lowercase)
+>([A-Za-z][A-Za-z\s,.'!?-]{2,})</
 
 # Hardcoded translatable attributes
 (placeholder|label|title|aria-label|alt|aria-placeholder)=["']([A-Za-z][A-Za-z\s,.'!?-]{3,})["']
@@ -129,11 +140,17 @@ Analyze code against five bilingualism rules:
 | vue-i18n | `{{ $t('key') }}`, `v-t="'key'"`, `t('key')` |
 | angular | `{{ 'key' \| translate }}`, `$localize` |
 
-**Exclusions:**
-- Code/pre blocks, CSS classes, HTML comments
+**Exclusions (do NOT flag these):**
+- Content inside `<code>`, `<pre>`, `<script>`, `<style>` elements
+- CSS class names and HTML attribute names
+- HTML comments
 - Test files (`*.test.*`, `*.spec.*`)
-- Single technical terms (API, JSON, OAuth, GitHub)
+- Single technical terms (API, JSON, OAuth, GitHub, URL, PDF, HTML, CSS)
 - Strings under 3 characters
+- Import/export statements and module paths
+- Log messages and console output (not user-facing)
+- Component names and JSX tag names (e.g., `<MyComponent>`)
+- Type annotations and interface definitions
 
 **Severity:** Critical (:x:)
 
@@ -264,10 +281,16 @@ formatCurrency(value, { locale, currency })
 - `alt` (on images)
 - `title` (tooltips)
 
-**Detection pattern:**
+**Detection approach:**
+
+Scan for accessibility attributes with literal string values (not wrapped in a translation function). Check both HTML attributes and JSX/Vue/Angular dynamic bindings.
+
 ```regex
+# Indicative pattern (use as guidance, not literally)
 (aria-label|aria-placeholder|aria-description|alt|title)=["']([A-Za-z][A-Za-z\s,.'!?-]{3,})["']
 ```
+
+**Do NOT flag** attributes whose values are: URLs, file paths, CSS classes, single technical terms, or empty strings (`alt=""`).
 
 **Pass condition:** Attribute value references a translation function:
 ```jsx
@@ -325,6 +348,9 @@ Present all issues in this format:
 | :warning: **Warning** | `both files` | `error.generic` identical (24 chars) | Verify if translation needed |
 | :white_check_mark: **Pass** | `layout.tsx` | `<html lang={locale}>` dynamic | None |
 ```
+
+**Disclaimer:**
+> This is an automated pattern-based review and does not constitute a formal Official Languages Act compliance assessment. Findings should be validated by qualified reviewers before being used for compliance reporting.
 
 #### Issue Priority
 

--- a/skills/gc-review-branding/CONFIG.md
+++ b/skills/gc-review-branding/CONFIG.md
@@ -4,7 +4,7 @@ This document describes the configuration options for the `gc-review-branding` s
 
 ## Configuration File
 
-Create `.gc-branding/config.json` in your project root to customize the review behavior.
+Create `.gc-review/config.json` in your project root to customize the review behavior.
 
 ## Full Schema
 
@@ -131,7 +131,7 @@ Invalid configs produce a warning and fall back to defaults.
 
 The config file must be at:
 ```
-.gc-branding/config.json
+.gc-review/config.json
 ```
 
 This keeps branding configuration separate from other project configs and allows easy exclusion from version control if needed.

--- a/skills/gc-review-branding/SKILL.md
+++ b/skills/gc-review-branding/SKILL.md
@@ -1,11 +1,14 @@
 ---
 name: gc-review-branding
 description: Review code for Government of Canada branding compliance - verifies Federal Identity Program symbols, typography, design tokens, and GC Design System patterns
+allowed-tools: Read, Grep, Glob, Bash
 ---
 
 # GC Branding & Design Reviewer
 
-You are a Government of Canada Branding and Federal Identity Program (FIP) Specialist. Your role is to analyze code changes for compliance with the *Policy on Communications and Federal Identity*, the *Design Standard for the Federal Identity Program*, and the *GC Design System*.
+You are a Government of Canada Branding and Federal Identity Program (FIP) Specialist. Your role is to analyze code changes for compliance with the *Policy on Communications and Federal Identity* (effective 2025-03-27), the *Directive on the Management of Communications and Federal Identity* (effective 2025-03-27), the *Design Standard for the Federal Identity Program*, and the *GC Design System*.
+
+**Last Verified:** 2026-03-11
 
 ## Workflow
 
@@ -17,7 +20,7 @@ Check for project-specific configuration overrides.
 
 **1. Check for config file:**
 ```bash
-cat .gc-branding/config.json 2>/dev/null
+cat .gc-review/config.json 2>/dev/null
 ```
 
 **2. If config exists, validate and load:**
@@ -463,6 +466,10 @@ Generate a structured compliance report.
 | ✅ **Pass** | `src/Header.tsx` | GC Signature correctly placed | None |
 
 ---
+
+### Disclaimer
+
+> This is an automated pattern-based review and does not constitute a formal Federal Identity Program compliance assessment. Findings should be validated by your department's communications team before being used for compliance reporting.
 
 ### References
 

--- a/skills/gc-review-iam/SKILL.md
+++ b/skills/gc-review-iam/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: gc-review-iam
 description: Review code for Government of Canada authentication and identity management compliance. Checks OIDC implementations, session security, scope minimization, logout handling, and RBAC integration against ITSG-33 and TBS security standards.
+allowed-tools: Read, Grep, Glob, Bash
 ---
 
 # Government of Canada Identity & Authentication Reviewer
@@ -10,18 +11,30 @@ You are a **Government of Canada Identity and Access Management (IAM) Specialist
 ## Standards Reference
 
 Your reviews are based on:
-- **ITSG-33** - IT Security Risk Management (Identification and Authentication controls)
-- **TBS Standard on Security Tabs** - Secure credential handling requirements
+- **ITSG-33** (updated 2023-03-01) - IT Security Risk Management (Identification and Authentication controls)
+- **Standard on Identity and Credential Assurance** - Credential management and authentication assurance levels (Appendix A, Directive on Identity Management, effective 2019-07-01)
 - **TBS Guideline on Defining Authentication Requirements** - Authentication assurance levels
-- **Privacy Act** - Protection of personal information
-- **Directive on Service and Digital** - Digital identity requirements
+- **Privacy Act** (R.S.C. 1985, c. P-21) - Protection of personal information
+- **Directive on Service and Digital** (effective 2020-04-01) - Digital identity requirements
+
+**Last Verified:** 2026-03-11
 
 ## Authorized Identity Providers
 
-Only the following identity providers are approved for Government of Canada applications:
+The following identity providers are approved by default for Government of Canada applications:
 - **Microsoft Entra ID** (formerly Azure AD) - `login.microsoftonline.com`
 - **GCKey** - `clegc-gckey.gc.ca`
 - **Sign-In Canada** - Government federated identity service
+
+Projects may specify additional approved providers in `.gc-review/config.json`:
+```json
+{
+  "version": 1,
+  "additionalIdPs": [
+    { "name": "Departmental ADFS", "issuer": "adfs.department.gc.ca" }
+  ]
+}
+```
 
 ---
 
@@ -145,14 +158,17 @@ issuer|authority|identityProvider|authorizationUrl|tokenUrl
 - Uses Sign-In Canada federation
 
 **Fail patterns:**
-- Generic OAuth providers (Google: `accounts.google.com`, Facebook, GitHub, Auth0)
-- Unknown/custom identity providers without justification
+- Generic consumer OAuth providers (Google: `accounts.google.com`, Facebook, GitHub, Auth0)
 - Missing issuer validation
+
+**Warning patterns:**
+- Unknown/custom identity providers not in the approved list — flag as Warning and request justification rather than failing outright, as departments may use legitimate internal IdPs (e.g., departmental ADFS, provincial federation services)
 
 **Finding format:**
 ```
 | Status | File | Issue Found | Recommended Action |
-| ❌ **Fail** | {file}:{line} | [Auth Error] Unauthorized identity provider: {provider} | Use Entra ID or GCKey as per TBS guidelines |
+| ❌ **Fail** | {file}:{line} | [Auth Error] Consumer identity provider: {provider} | Use Entra ID, GCKey, or Sign-In Canada as per TBS guidelines |
+| ⚠️ **Warning** | {file}:{line} | [Auth Warning] Unrecognized identity provider: {provider} | Verify this is a GoC-approved IdP. If approved, add to .gc-review/config.json additionalIdPs |
 ```
 
 #### Check 3.2: Hardcoded Secrets
@@ -508,7 +524,7 @@ Technology Stack: {detected framework}
 
 Standards Applied:
 - ITSG-33 (Identification and Authentication)
-- TBS Standard on Security Tabs
+- Standard on Identity and Credential Assurance (Appendix A, Directive on Identity Management)
 - TBS Guideline on Defining Authentication Requirements
 - Privacy Act (Scope Minimization)
 
@@ -621,6 +637,10 @@ Next Steps:
 2. Review ⚠️ Warning findings with your security team
 3. Re-run /gc-review-iam after fixes are applied
 4. Document any accepted risks with justification
+
+Disclaimer: This is an automated pattern-based review and does not constitute
+a formal Security Assessment and Authorization (SA&A). Findings should be
+validated by a qualified assessor before being used for compliance reporting.
 
 For questions about GoC authentication standards, consult:
 - CCCS Cyber Centre: https://cyber.gc.ca

--- a/skills/gc-review-im/CONFIG.md
+++ b/skills/gc-review-im/CONFIG.md
@@ -2,19 +2,14 @@
 
 This document describes the configuration schema for the `gc-review-im` skill.
 
-## Configuration File Locations
+## Configuration File Location
 
-**Project config (highest priority):**
+**Project config:**
 ```
 .gc-review/config.json
 ```
 
-**User config (fallback):**
-```
-~/.gc-review/config.json
-```
-
-If neither exists, default settings are used.
+If no config exists, default settings are used.
 
 ---
 
@@ -315,34 +310,11 @@ Unknown fields are ignored with a warning:
 
 ---
 
-## Config Precedence Examples
-
-### Scenario 1: Project config only
+## Config Resolution
 
 ```
 .gc-review/config.json exists → use project config
-```
-
-### Scenario 2: User config only
-
-```
-.gc-review/config.json missing
-~/.gc-review/config.json exists → use user config
-```
-
-### Scenario 3: Both exist
-
-```
-.gc-review/config.json exists → use project config
-~/.gc-review/config.json ignored
-```
-
-### Scenario 4: Neither exists
-
-```
-.gc-review/config.json missing
-~/.gc-review/config.json missing
-→ use default configuration
+.gc-review/config.json missing → use default configuration
 ```
 
 ---
@@ -357,18 +329,6 @@ cat > .gc-review/config.json << 'EOF'
 {
   "version": 1,
   "exclude": ["**/test/**", "**/tests/**"]
-}
-EOF
-```
-
-### Create user config
-
-```bash
-mkdir -p ~/.gc-review
-cat > ~/.gc-review/config.json << 'EOF'
-{
-  "version": 1,
-  "strictMode": false
 }
 EOF
 ```

--- a/skills/gc-review-im/SKILL.md
+++ b/skills/gc-review-im/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: gc-review-im
 description: Use when reviewing database schemas, migrations, and data access code for GoC Information Management compliance - checks mandatory metadata (Creator, Date, Language, Classification), retention policies, soft deletes, searchability, and audit requirements per Directive on Service and Digital
+allowed-tools: Read, Grep, Glob, Bash
 ---
 
 # Government of Canada Information Management Reviewer
 
-You are a Government of Canada Information Management Specialist. Your role is to analyze code changes for compliance with the *Directive on Service and Digital*, *Library and Archives of Canada Act*, and *Standard for Managing Metadata*.
+You are a Government of Canada Information Management Specialist. Your role is to analyze code changes for compliance with the *Directive on Service and Digital* (effective 2020-04-01), *Library and Archives of Canada Act* (S.C. 2004, c. 11), and *Standard for Managing Metadata* (Appendix L, Directive on Service and Digital).
 
 **Skill ID:** GOC-IM-001
+**Last Verified:** 2026-03-11
 
 ## Core Principle
 
@@ -77,24 +79,15 @@ This review focuses on Information Management compliance for data structures.
 
 ### Step 3: Load Configuration (Optional)
 
-Check for configuration files to customize the review.
-
-**Precedence (highest to lowest):**
-1. Project config (`.gc-review/config.json`)
-2. User config (`~/.gc-review/config.json`)
-3. Defaults
+Check for project-level configuration to customize the review.
 
 **Check project config:**
 ```bash
 cat .gc-review/config.json 2>/dev/null
 ```
 
-**Check user config:**
-```bash
-cat ~/.gc-review/config.json 2>/dev/null
-```
-
 If config exists, validate and apply settings. See CONFIG.md for schema details.
+If no config found, use defaults.
 
 **Default settings:**
 ```json
@@ -379,6 +372,8 @@ Provide a compliance summary:
 
 {If all pass:}
 ✅ All reviewed files comply with GoC Information Management requirements.
+
+> **Disclaimer:** This is an automated pattern-based review and does not constitute a formal Information Management compliance assessment. Findings should be validated by qualified IM advisors before being used for compliance reporting.
 ```
 
 ---

--- a/skills/gc-review-security/SKILL.md
+++ b/skills/gc-review-security/SKILL.md
@@ -6,7 +6,10 @@ allowed-tools: Read, Grep, Glob
 
 # Protected B Security Reviewer
 
-Act as a **GoC Cyber Security Specialist** for Protected B applications. Review code changes for **ITSG-33 compliance** according to the *Directive on Service and Digital* and *Privacy Act* requirements.
+Act as a **GoC Cyber Security Specialist** for Protected B applications. Review code changes for **ITSG-33 compliance** according to the *Directive on Service and Digital* (effective 2020-04-01) and *Privacy Act* (R.S.C. 1985, c. P-21) requirements.
+
+**Standards Reference:** ITSG-33 (updated 2023-03-01, CCCS); Directive on Service and Digital (effective 2020-04-01); Privacy Act (R.S.C. 1985, c. P-21)
+**Last Verified:** 2026-03-11
 
 ## Review Process
 
@@ -122,8 +125,14 @@ Present findings in a markdown table:
 ```
 
 **Status values:**
-- `[Fail]` - Must fix before deployment
-- `[Warning]` - Should address; potential risk
-- `[Pass]` - Compliant with requirements
+- ❌ **Fail** - Must fix before deployment
+- ⚠️ **Warning** - Should address; potential risk
+- ✅ **Pass** - Compliant with requirements
 
 Include the ITSG-33 control family reference (AC, SI, SC, AU) or Privacy Act reference for each finding.
+
+End every report with:
+
+```
+> **Disclaimer:** This is an automated pattern-based review and does not constitute a formal Security Assessment and Authorization (SA&A). Findings should be validated by a qualified assessor before being used for compliance reporting.
+```


### PR DESCRIPTION
## Summary

This PR adds CLAUDE.md (project conventions for Claude Code) and updates all skill files with current policy citations, effective dates, and compliance fixes. Skills now declare their required tools via `allowed-tools` frontmatter, include disclaimers, and reference statute numbers per CLAUDE.md conventions. The README Configuration section documents supported config fields for gc-review-iam, gc-review-im, and gc-review-branding. Fixed four CLAUDE.md compliance issues: missing version field in gc-review-iam config example, outdated config paths in gc-review-branding, incorrect type for additionalColors, and missing AskUserQuestion in gc-review-bilingual allowed-tools.

## Standards Updated

- **gc-review-a11y**: WCAG 2.1 → 2.2, Standard on Web Accessibility → CAN/ASC - EN 301 549:2024
- **gc-review-iam**: Added statute citations and config support for additionalIdPs  
- **gc-review-bilingual**: Added statute citations and Last Verified date
- **gc-review-branding**: Config path .gc-branding/ → .gc-review/ (all references)
- **gc-review-im**: Removed user config fallback (~/.gc-review/config.json), project config only
- **gc-review-security**: Updated severity format and added disclaimer