### PR TITLE
Make README fully bilingual English/French

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
-# GC Code Review Skills
+# GC Code Review Skills / <span lang="fr">Compétences de revue de code GC</span>
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.md)
 
 A collection of Claude Code skills that help developers review code for compliance with Government of Canada (GoC) digital standards. These skills automate compliance checking across accessibility, security, information management, identity and authentication, official languages, and GC branding requirements.
+
+<div lang="fr">
+
+Une collection de compétences Claude Code qui aident les développeurs à vérifier la conformité du code aux normes numériques du gouvernement du Canada (GC). Ces compétences automatisent la vérification de la conformité en matière d'accessibilité, de sécurité, de gestion de l'information, d'identité et d'authentification, de langues officielles et d'image de marque du GC.
+
+</div>
 
 ---
 
@@ -16,25 +22,61 @@ Ce projet n'est pas affilié, endossé ou parrainé par le gouvernement du Canad
 
 ---
 
-## Available Skills
+## Available Skills / <span lang="fr">Compétences disponibles</span>
 
 ### `gc-review-a11y`
 Reviews code for WCAG 2.2 Level AA compliance. Checks semantic HTML, ARIA patterns, focus management, text alternatives, and visual integrity following CAN/ASC - EN 301 549:2024.
 
+<div lang="fr">
+
+Vérifie la conformité du code au niveau AA des WCAG 2.2. Contrôle le HTML sémantique, les patrons ARIA, la gestion du focus, les alternatives textuelles et l'intégrité visuelle selon CAN/ASC - EN 301 549:2024.
+
+</div>
+
 ### `gc-review-security`
 Reviews code for Protected B security compliance. Evaluates access control, input validation, encryption, secrets management, and logging against ITSG-33 controls.
+
+<div lang="fr">
+
+Vérifie la conformité du code aux exigences de sécurité Protégé B. Évalue le contrôle d'accès, la validation des entrées, le chiffrement, la gestion des secrets et la journalisation selon les contrôles ITSG-33.
+
+</div>
 
 ### `gc-review-im`
 Reviews database schemas and data access code for information management compliance. Checks mandatory metadata fields, retention policies, soft deletes, and audit requirements per the Directive on Service and Digital.
 
+<div lang="fr">
+
+Vérifie les schémas de bases de données et le code d'accès aux données pour la conformité en gestion de l'information. Contrôle les champs de métadonnées obligatoires, les politiques de conservation, la suppression douce et les exigences d'audit selon la Directive sur les services et le numérique.
+
+</div>
+
 ### `gc-review-iam`
 Reviews authentication implementations for GoC identity standards. Checks OIDC configuration, session security, scope minimization, and RBAC integration against the Directive on Identity Management and Standard on Identity and Credential Assurance.
+
+<div lang="fr">
+
+Vérifie les implémentations d'authentification selon les normes d'identité du GC. Contrôle la configuration OIDC, la sécurité des sessions, la minimisation des portées et l'intégration RBAC selon la Directive sur la gestion de l'identité et la Norme sur l'assurance de l'identité et des justificatifs.
+
+</div>
 
 ### `gc-review-branding`
 Reviews code for Federal Identity Program compliance. Verifies GC signatures, Canada wordmark usage, typography, color tokens, and mandatory footer elements per the Policy on Communications and Federal Identity.
 
+<div lang="fr">
+
+Vérifie la conformité du code au Programme de coordination de l'image de marque. Contrôle les signatures du GC, l'utilisation du mot-symbole « Canada », la typographie, les jetons de couleur et les éléments obligatoires du pied de page selon la Politique sur les communications et l'image de marque.
+
+</div>
+
 ### `gc-review-bilingual`
 Reviews code for Official Languages Act compliance. Checks for hardcoded strings, translation file parity, locale-aware routing, and equal prominence of English and French content.
+
+<div lang="fr">
+
+Vérifie la conformité du code à la Loi sur les langues officielles. Contrôle les chaînes codées en dur, la parité des fichiers de traduction, le routage selon la langue et la proéminence égale du contenu en anglais et en français.
+
+</div>
 
 ---
 
@@ -44,11 +86,23 @@ Reviews code for Official Languages Act compliance. Checks for hardcoded strings
 npx skills add dougkeefe/gc-code-skills
 ```
 
+<div lang="fr">
+
+Installez les compétences en exécutant la commande ci-dessus dans votre terminal.
+
+</div>
+
 ---
 
-## Quick Start
+## Quick Start / <span lang="fr">Démarrage rapide</span>
 
 Invoke a skill during a Claude Code session:
+
+<div lang="fr">
+
+Invoquez une compétence pendant une session Claude Code :
+
+</div>
 
 ```
 /gc-review-a11y
@@ -62,6 +116,12 @@ Invoke a skill during a Claude Code session:
 
 Some skills support project-level configuration via `.gc-review/config.json`. This lets you tailor reviews to your project's specific requirements.
 
+<div lang="fr">
+
+Certaines compétences prennent en charge une configuration au niveau du projet via `.gc-review/config.json`. Cela vous permet d'adapter les revues aux exigences spécifiques de votre projet.
+
+</div>
+
 ```bash
 mkdir -p .gc-review
 cat > .gc-review/config.json << 'EOF'
@@ -71,7 +131,7 @@ cat > .gc-review/config.json << 'EOF'
 EOF
 ```
 
-### Supported configuration by skill
+### Supported configuration by skill / <span lang="fr">Configuration prise en charge par compétence</span>
 
 #### `gc-review-iam`
 
@@ -120,6 +180,12 @@ Contributions in English and French are welcome.
 
 ---
 
-## License
+## License / <span lang="fr">Licence</span>
 
 MIT - see [LICENSE.md](LICENSE.md)
+
+<div lang="fr">
+
+MIT - voir [LICENSE.md](LICENSE.md)
+
+</div>


### PR DESCRIPTION
## Summary
- Add French translations to all README sections (title, Available Skills, Installation, Quick Start, Configuration, License)
- Follow existing semantic HTML conventions with `lang="fr"` attributes for accessibility
- Maintain English-first structure with French content following in `<div lang="fr">` blocks
- Tables remain English-only as they reference code identifiers

This completes the bilingual documentation goal, ensuring equal prominence of English and French content throughout the project documentation.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>