### PR TITLE
Add gc-review-all orchestrator skill for consolidated GC audits

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
         "source": "url",
         "url": "https://github.com/dougkeefe/gc-code-skills.git"
       },
-      "description": "Claude Code skills for Government of Canada digital standards compliance reviews — accessibility, security, information management, identity & authentication, branding, and bilingual support.",
+      "description": "Claude Code skills for Government of Canada digital standards compliance reviews — accessibility, security, information management, identity & authentication, branding, bilingual support, and consolidated audit reports.",
       "version": "1.0.0",
       "author": {
         "name": "Doug Keefe",
@@ -28,6 +28,7 @@
         "wcag",
         "bilingual",
         "code-review",
+        "audit",
         "branding",
         "information-management",
         "identity-authentication"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gc-code-skills",
-  "description": "Claude Code skills for Government of Canada digital standards compliance reviews — accessibility, security, information management, identity & authentication, branding, and bilingual support.",
+  "description": "Claude Code skills for Government of Canada digital standards compliance reviews — accessibility, security, information management, identity & authentication, branding, bilingual support, and consolidated audit reports.",
   "version": "1.0.0",
   "author": {
     "name": "Doug Keefe",
@@ -17,6 +17,7 @@
     "wcag",
     "bilingual",
     "code-review",
+    "audit",
     "branding",
     "information-management",
     "identity-authentication"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Installation: `npx skills add dougkeefe/gc-code-skills`
 - `skills/gc-review-*/CONFIG.md` — Configuration schema docs (gc-review-im, gc-review-branding)
 - `.claude-plugin/` — Plugin metadata for Claude Code marketplace
 
-Six skills exist: `gc-review-a11y`, `gc-review-security`, `gc-review-im`, `gc-review-iam`, `gc-review-branding`, `gc-review-bilingual`.
+Seven skills exist: `gc-review-a11y`, `gc-review-security`, `gc-review-im`, `gc-review-iam`, `gc-review-branding`, `gc-review-bilingual`, `gc-review-all`.
 
 ## Skill File Format
 
@@ -24,7 +24,7 @@ Each SKILL.md follows this structure:
 ---
 name: gc-review-[domain]
 description: [What the skill reviews]
-allowed-tools: [Comma-separated list: Read, Grep, Glob, Bash, Edit, AskUserQuestion]
+allowed-tools: [Comma-separated list: Read, Grep, Glob, Bash, Edit, Write, Agent, AskUserQuestion]
 ---
 ```
 
@@ -43,6 +43,7 @@ Followed by markdown containing:
 - **Configuration path**: Skills that support project-level config read from `.gc-review/config.json`. The config uses `"version": 1` as a required field.
 - **allowed-tools must list every tool the skill uses**, including AskUserQuestion if the workflow calls it.
 - **Severity levels**: ❌ Fail (must fix), ⚠️ Warning (should address), ✅ Pass (compliant).
+- **Agent tool for orchestration**: `gc-review-all` uses the `Agent` tool to spawn sub-agents for each domain skill. Individual domain skills do not use `Agent`.
 - **Bilingual**: README sections include French translations. Contributions in both English and French are welcome.
 
 ## No Build/Test/Lint

--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ Vérifie la conformité du code à la Loi sur les langues officielles. Contrôle
 
 </div>
 
+### `gc-review-all`
+Runs all six GC compliance review skills and produces a consolidated audit report with a prioritized remediation plan covering accessibility, security, information management, identity & authentication, branding, and bilingual compliance.
+
+<div lang="fr">
+
+Lance les six compétences de revue de conformité du GC et produit un rapport d'audit consolidé avec un plan de remédiation priorisé couvrant l'accessibilité, la sécurité, la gestion de l'information, l'identité et l'authentification, l'image de marque et la conformité bilingue.
+
+</div>
+
 ---
 
 ## Installation
@@ -108,6 +117,7 @@ Invoquez une compétence pendant une session Claude Code :
 /gc-review-a11y
 /gc-review-security
 /gc-review-branding
+/gc-review-all          # full audit across all domains
 ```
 
 ---

--- a/skills/gc-review-all/SKILL.md
+++ b/skills/gc-review-all/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: gc-review-all
+description: Run all GC compliance review skills and produce a consolidated audit report with prioritized remediation plan. Use when you want a full-spectrum review across accessibility, security, information management, identity, branding, and bilingual compliance.
+allowed-tools: Read, Grep, Glob, Bash, Agent, Write, AskUserQuestion
+---
+
+# GC Full Compliance Audit — Orchestrator
+
+You are a **Government of Canada Compliance Audit Orchestrator**. Your role is to run every gc-review skill against the current codebase using the Agent tool, consolidate findings into a unified audit report, and produce a prioritized remediation plan.
+
+**Skill ID:** GOC-ALL-001
+**Sub-Skills:** gc-review-a11y, gc-review-security, gc-review-im, gc-review-iam, gc-review-branding, gc-review-bilingual
+**Last Verified:** 2026-03-26
+
+---
+
+## Workflow
+
+Execute these steps in order.
+
+### Step 0: Pre-flight Checks
+
+Before launching agents, verify the environment:
+
+```bash
+# 1. Confirm git repository
+git rev-parse --git-dir 2>/dev/null
+
+# 2. Confirm there are changes or code to review
+git diff --cached --stat || git diff --stat || git diff main...HEAD --stat 2>/dev/null
+
+# 3. List file types present (determines which skills are relevant)
+git ls-files | sed 's/.*\.//' | sort | uniq -c | sort -rn
+```
+
+If the directory is not a git repository, inform the user and stop.
+
+### Step 1: Determine Applicable Skills
+
+Not every skill applies to every codebase. Use file-type detection to decide which skills to run:
+
+| Skill | Applies When These Files Exist |
+|-------|-------------------------------|
+| `gc-review-a11y` | `.html`, `.htm`, `.jsx`, `.tsx`, `.vue`, `.svelte`, `.css`, `.scss` |
+| `gc-review-security` | Any code files (`.js`, `.ts`, `.py`, `.java`, `.cs`, `.go`, `.rb`, `.php`, `.rs`, config files) |
+| `gc-review-im` | Database schemas, migrations, ORM models (`.sql`, `migration*`, `model*`, `schema*`) |
+| `gc-review-iam` | Auth-related files (`auth*`, `login*`, `session*`, `oidc*`, `.env`, config files with auth sections) |
+| `gc-review-branding` | `.html`, `.htm`, `.jsx`, `.tsx`, `.vue`, `.css`, `.scss`, image assets |
+| `gc-review-bilingual` | `.html`, `.jsx`, `.tsx`, `.vue`, locale/i18n directories, translation files (`.json`, `.yml`, `.po`) |
+
+**Rules:**
+- `gc-review-security` always runs — every codebase has security surface.
+- For all other skills, check if relevant files exist. If none are found, mark the skill as **Skipped (no applicable files)** in the final report.
+- If unsure whether a skill applies, run it — false negatives are worse than a quick scan that finds nothing.
+
+### Step 2: Load Configuration
+
+Check for project-level configuration at `.gc-review/config.json`. If present and valid JSON with `"version": 1`, read any `gc-review-all` settings:
+
+```json
+{
+  "version": 1,
+  "gc-review-all": {
+    "include": ["a11y", "security", "im", "iam", "branding", "bilingual"],
+    "exclude": [],
+    "parallel": true
+  }
+}
+```
+
+- `include` — Skills to run (default: all six)
+- `exclude` — Skills to skip (overrides include)
+- `parallel` — Launch agents in parallel when available (default: true)
+
+Pass the full config through to each agent so individual skill settings are respected.
+
+### Step 3: Launch Agent Loop
+
+For each applicable skill, use the **Agent tool** to spawn a review agent with the following prompt template:
+
+```
+You are running a GC compliance review sub-task.
+
+Read the skill file at: skills/gc-review-{domain}/SKILL.md
+
+Follow its workflow steps exactly:
+- Detect changes (Step 1)
+- Load config if applicable (Step 2)
+- Gather context (Step 3)
+- Run analysis (Step 4)
+- Present findings in the specified table format (Step 5)
+- Skip the fix selection step — report only
+
+Return your findings as a markdown table with columns:
+Status | File | Issue Found | Recommended Action
+
+End with a summary line:
+SUMMARY: {critical_count} critical, {warning_count} warnings, {pass_count} passes
+```
+
+**Execution strategy:**
+- If the `parallel` config option is true (default), launch all applicable skill agents in parallel for speed using multiple Agent tool calls in a single message.
+- If `parallel` is false, run skills sequentially, one agent at a time.
+- If the Agent tool is unavailable, run skills sequentially yourself: read each SKILL.md, execute its workflow, then move to the next.
+
+### Step 4: Collect and Normalize Results
+
+As each agent completes, collect its results into a unified structure:
+
+```
+For each completed skill:
+  - Domain tag: [A11Y], [SECURITY], [IM], [IAM], [BRANDING], [BILINGUAL]
+  - Findings table rows (with domain tag prepended)
+  - Summary counts
+  - Compliance status (PASS / FAIL)
+```
+
+Handle agent failures gracefully:
+- If an agent errors out → mark domain as **⚠️ Review Incomplete** and note the error
+- If an agent finds no applicable files → mark as **⏭️ Skipped**
+- If an agent completes → record PASS or FAIL
+
+### Step 5: Present Consolidated Audit Report
+
+Combine all results into this format:
+
+```markdown
+# GC Full Compliance Audit Report
+
+**Repository:** {repo name}
+**Branch:** {branch}
+**Date:** {date}
+**Skills Executed:** {count} of 6
+
+---
+
+## Executive Summary
+
+| Domain | Status | ❌ Critical | ⚠️ Warnings | ✅ Passes |
+|--------|--------|------------|-------------|----------|
+| Accessibility (A11Y) | PASS/FAIL/SKIPPED | {n} | {n} | {n} |
+| Security | PASS/FAIL/SKIPPED | {n} | {n} | {n} |
+| Information Management | PASS/FAIL/SKIPPED | {n} | {n} | {n} |
+| Identity & Access Mgmt | PASS/FAIL/SKIPPED | {n} | {n} | {n} |
+| Branding & FIP | PASS/FAIL/SKIPPED | {n} | {n} | {n} |
+| Bilingual (OLA) | PASS/FAIL/SKIPPED | {n} | {n} | {n} |
+| **TOTALS** | **{overall}** | **{n}** | **{n}** | **{n}** |
+
+**Overall Compliance:** PASS / FAIL
+(PASS = zero ❌ Critical across all domains; FAIL = one or more)
+
+---
+
+## Detailed Findings
+
+### Accessibility (A11Y)
+
+| Status | File | Issue Found | Recommended Action |
+| :--- | :--- | :--- | :--- |
+| ... | ... | ... | ... |
+
+### Security
+
+| Status | File | Issue Found | Recommended Action |
+| :--- | :--- | :--- | :--- |
+| ... | ... | ... | ... |
+
+{Repeat for each domain that ran}
+
+---
+```
+
+### Step 6: Generate Prioritized Remediation Plan
+
+After the audit report, produce a remediation plan that helps the team triage and fix issues efficiently:
+
+```markdown
+## Remediation Plan
+
+### Priority 1 — Critical Fixes (Must Address)
+
+Issues that block compliance. Fix these first.
+
+| # | Domain | File | Issue | Fix Description | Effort |
+|---|--------|------|-------|-----------------|--------|
+| 1 | [SECURITY] | `auth.ts:42` | Hardcoded secret | Move to env var | Low |
+| 2 | [A11Y] | `Form.tsx:18` | Missing label | Add `<label>` | Low |
+| ... | | | | | |
+
+### Priority 2 — Warnings (Should Address)
+
+Issues that risk non-compliance or degrade quality.
+
+| # | Domain | File | Issue | Fix Description | Effort |
+|---|--------|------|-------|-----------------|--------|
+| ... | | | | | |
+
+### Priority 3 — Recommendations
+
+Improvements that strengthen compliance posture.
+
+| # | Domain | Recommendation |
+|---|--------|---------------|
+| ... | | |
+```
+
+**Effort estimation heuristic:**
+- **Low** — Single-line or single-file change (add an attribute, rename a variable, add a label)
+- **Medium** — Multi-file change or requires testing (refactor auth flow, add i18n keys, restructure headings)
+- **High** — Architectural change or cross-cutting concern (implement RBAC, add retention framework, restructure component hierarchy)
+
+**Ordering rules within each priority tier:**
+1. Security issues first (they carry the highest risk)
+2. Then by effort: Low → Medium → High (maximize quick wins)
+3. Group related issues (e.g., all missing labels together, all missing translations together)
+
+### Step 7: Offer Next Steps
+
+Use AskUserQuestion to ask:
+
+**Question:** "How would you like to proceed with the remediation plan?"
+
+**Options:**
+1. "Fix all critical issues" — Walk through each Priority 1 fix, showing before/after code, confirming before each edit
+2. "Fix by domain" — Choose a specific domain to remediate first
+3. "Export report" — Save the full audit report and remediation plan to a markdown file
+4. "None (just report)" — Keep as reference, no fixes
+
+If the user chooses to fix by domain, use AskUserQuestion to present the applicable domains.
+
+If the user chooses to fix issues, use the Agent tool to spawn domain-specific agents that have the appropriate tools (including Edit) to apply fixes. Each fix must be shown to the user and confirmed via AskUserQuestion before applying.
+
+If the user chooses to export, use Bash to create the output directory (`mkdir -p .gc-review/reports`) and the Write tool to save to `.gc-review/reports/audit-{date}.md`.
+
+---
+
+## Output Files
+
+When the user requests an export, save to:
+
+```
+.gc-review/
+├── config.json           (project config, if present)
+└── reports/
+    └── audit-{date}.md   (full audit report + remediation plan)
+```
+
+---
+
+## Disclaimer / <span lang="fr">Avis de non-responsabilité</span>
+
+> This is an automated pattern-based review and does not constitute a formal compliance assessment. Findings should be validated by qualified assessors through the appropriate Security Assessment and Authorization (SA&A) process before being used for compliance reporting. Individual sub-skill disclaimers also apply.
+
+<div lang="fr">
+
+> Il s'agit d'un examen automatisé basé sur des modèles et ne constitue pas une évaluation formelle de la conformité. Les conclusions doivent être validées par des évaluateurs qualifiés dans le cadre du processus approprié d'évaluation et d'autorisation de sécurité (EAS) avant d'être utilisées pour les rapports de conformité. Les avis de non-responsabilité des sous-compétences individuelles s'appliquent également.
+
+</div>
+
+---
+
+## Remember
+
+Your goal is a **single-pass, comprehensive compliance picture**. The value of this skill over running individual reviews is:
+
+1. **Completeness** — No domain is accidentally skipped
+2. **Cross-domain visibility** — A security issue might relate to an IAM finding; a branding issue might overlap with bilingual requirements
+3. **Prioritized action** — One ranked remediation list instead of six separate reports
+4. **Effort estimation** — Helps teams plan sprints and allocate work
+
+Run every applicable skill. Consolidate ruthlessly. Prioritize clearly. Make it actionable.


### PR DESCRIPTION
## Summary

- Adds `gc-review-all`, a new orchestrator skill that spawns sub-agents for all six domain review skills (a11y, security, IM, IAM, branding, bilingual) and consolidates findings into a unified audit report with a prioritized remediation plan.
- Updates CLAUDE.md to document the seventh skill, the Agent tool orchestration convention, and expanded allowed-tools list.
- Updates README.md with bilingual (EN/FR) description and usage example for the new skill.
- Updates plugin metadata (marketplace.json, plugin.json) with revised descriptions and `audit` keyword.

## Test plan

- [ ] Verify `gc-review-all` SKILL.md frontmatter is valid YAML with correct allowed-tools
- [ ] Run `/gc-review-all` against a sample repo and confirm all six sub-skills are invoked
- [ ] Confirm consolidated report renders correctly with executive summary and remediation plan
- [ ] Verify README French translation is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)