### PR TITLE
gc-review-bilingual: implement efficacy-audit recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ Vérifie la conformité du code au Programme de coordination de l'image de marqu
 </div>
 
 ### `gc-review-bilingual`
-Reviews code for Official Languages Act compliance. Checks for hardcoded strings, translation file parity, locale-aware routing, and equal prominence of English and French content.
+Reviews code for Official Languages Act compliance. Checks for hardcoded strings, translation file parity, locale-aware routing and formatting, active offer and language-toggle wording, and equal prominence of English and French content.
 
 <div lang="fr">
 
-Vérifie la conformité du code à la Loi sur les langues officielles. Contrôle les chaînes codées en dur, la parité des fichiers de traduction, le routage selon la langue et la proéminence égale du contenu en anglais et en français.
+Vérifie la conformité du code à la Loi sur les langues officielles. Contrôle les chaînes codées en dur, la parité des fichiers de traduction, le routage et le formatage selon la langue, l'offre active et le libellé du sélecteur de langue, ainsi que la proéminence égale du contenu en anglais et en français.
 
 </div>
 
@@ -179,6 +179,53 @@ See [`skills/gc-review-im/CONFIG.md`](skills/gc-review-im/CONFIG.md) for the ful
 | `wordmark.componentName` | `string` | Custom component name for Canada wordmark |
 | `additionalColors` | `object` | Extra approved color tokens (map of token name to hex value) |
 | `excludePatterns` | `string[]` | File patterns to skip |
+
+#### `gc-review-bilingual`
+
+Options are nested under the `"bilingual"` key in `.gc-review/config.json`:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `translationFiles` | `object` | auto-detected | Glob patterns for translation files, with `english` and `french` arrays |
+| `scanPaths` | `string[]` | framework-based | Glob patterns for UI source files to scan |
+| `excludePaths` | `string[]` | tests, `node_modules` | Glob patterns for files to exclude |
+| `framework` | `string` | `"auto"` | i18n framework (`next-intl`, `react-i18next`, `vue-i18n`, `angular`, `svelte-i18n`, or `auto`) |
+| `minStringLength` | `number` | `3` | Minimum string length to flag as hardcoded |
+| `identicalThreshold` | `number` | `20` | Minimum length of identical EN/FR strings to flag |
+| `ignoreWords` | `string[]` | technical terms | Words never flagged (proper nouns, technical terms) |
+| `strictMode` | `boolean` | `false` | When true, warnings are treated as failures |
+
+```json
+{
+  "version": 1,
+  "bilingual": {
+    "translationFiles": { "english": ["messages/en.json"], "french": ["messages/fr.json"] },
+    "scanPaths": ["src/**/*.tsx"],
+    "identicalThreshold": 20
+  }
+}
+```
+
+The legacy `.bilingual-review.json` file remains a deprecated fallback for one release.
+
+<div lang="fr">
+
+Les options sont imbriquées sous la clé `"bilingual"` dans `.gc-review/config.json` :
+
+| Champ | Type | Défaut | Description |
+|-------|------|--------|-------------|
+| `translationFiles` | `object` | détection automatique | Motifs glob des fichiers de traduction, avec les tableaux `english` et `french` |
+| `scanPaths` | `string[]` | selon le cadriciel | Motifs glob des fichiers source d'interface à analyser |
+| `excludePaths` | `string[]` | tests, `node_modules` | Motifs glob des fichiers à exclure |
+| `framework` | `string` | `"auto"` | Cadriciel d'i18n (`next-intl`, `react-i18next`, `vue-i18n`, `angular`, `svelte-i18n` ou `auto`) |
+| `minStringLength` | `number` | `3` | Longueur minimale d'une chaîne signalée comme codée en dur |
+| `identicalThreshold` | `number` | `20` | Longueur minimale des chaînes EN/FR identiques à signaler |
+| `ignoreWords` | `string[]` | termes techniques | Mots jamais signalés (noms propres, termes techniques) |
+| `strictMode` | `boolean` | `false` | Si vrai, les avertissements sont traités comme des échecs |
+
+Le fichier hérité `.bilingual-review.json` demeure une solution de repli dépréciée pour une version.
+
+</div>
 
 ---
 

--- a/skills/gc-review-bilingual/README.md
+++ b/skills/gc-review-bilingual/README.md
@@ -4,18 +4,10 @@ A Claude Code skill for reviewing code against Government of Canada Official Lan
 
 ## Installation
 
+Install the full skill collection (this skill included):
+
 ```bash
-claude skills add /path/to/gc-review-bilingual
-```
-
-Or add to your project's `.claude/settings.json`:
-
-```json
-{
-  "skills": [
-    "/path/to/gc-review-bilingual"
-  ]
-}
+npx skills add dougkeefe/gc-code-skills
 ```
 
 ## Usage
@@ -40,17 +32,23 @@ Flags hardcoded text in UI components that should use translation functions.
 ### B. Dictionary Parity
 Compares English and French translation files for:
 - Missing keys in either language
-- Placeholder values (TODO, TRANSLATE ME)
+- Placeholder values (TODO, `[TRANSLATE]`, `[French translation needed]`)
 - Suspiciously identical long strings
 
 ### C. Localized Navigation & Routing
 Verifies locale-aware routing and dynamic `<html lang>` attributes.
 
 ### D. Locale-Aware Formatting
-Checks that dates, numbers, and currencies use `Intl` formatters with locale parameters.
+Checks that dates, numbers, and currencies rendered in the UI use `Intl` formatters with locale parameters.
 
 ### E. Accessibility Parity
 Ensures `aria-label`, `alt`, and `title` attributes use translation keys.
+
+### F. Active Offer, Language Toggle & Equal Prominence
+Verifies a language switch mechanism exists (active offer, OLA s. 28), toggle wording follows the Canada.ca pattern ("Français"/"English" full words; "FR"/"EN" only on small screens with a `title` attribute), and both languages get equal prominence and correct order (OLA s. 29; DOLCS s. 6.1.1).
+
+### G. Website Requirements (DOLCS s. 6.6)
+Checks metadata language, UTF-8/diacritics support, hyperlink language notices, and bilingual domain names.
 
 ## Supported Frameworks
 
@@ -62,21 +60,28 @@ Ensures `aria-label`, `alt`, and `title` attributes use translation keys.
 
 ## Configuration
 
-Create `.bilingual-review.json` in your project root:
+Create `.gc-review/config.json` in your project root, with bilingual options under the `"bilingual"` key:
 
 ```json
 {
-  "translationFiles": {
-    "english": ["messages/en.json"],
-    "french": ["messages/fr.json"]
-  },
-  "scanPaths": ["src/**/*.tsx", "app/**/*.tsx"],
-  "excludePaths": ["**/*.test.*"],
-  "minStringLength": 3,
-  "identicalThreshold": 20,
-  "ignoreWords": ["GitHub", "OAuth", "API"]
+  "version": 1,
+  "bilingual": {
+    "translationFiles": {
+      "english": ["messages/en.json"],
+      "french": ["messages/fr.json"]
+    },
+    "scanPaths": ["src/**/*.tsx", "app/**/*.tsx"],
+    "excludePaths": ["**/*.test.*"],
+    "framework": "auto",
+    "minStringLength": 3,
+    "identicalThreshold": 20,
+    "ignoreWords": ["GitHub", "OAuth", "API"],
+    "strictMode": false
+  }
 }
 ```
+
+The legacy `.bilingual-review.json` file is still read as a deprecated fallback for one release; a warning is emitted asking you to migrate.
 
 ## Output Format
 
@@ -84,15 +89,38 @@ The skill produces a structured report:
 
 | Status | File | Issue Found | Recommended Action |
 |--------|------|-------------|-------------------|
-| :x: Fail | `Header.tsx:24` | Hardcoded string "Sign In" | Use `t('auth.signIn')` |
-| :x: Fail | `fr.json` | Missing key `dashboard.title` | Add French translation |
-| :warning: Warning | `fr.json` | `nav.help` is "TODO" | Provide translation |
-| :white_check_mark: Pass | `layout.tsx` | Dynamic `lang` attribute | None |
+| ❌ Fail | `Header.tsx:24` | Hardcoded string "Sign In" | Use `t('auth.signIn')` |
+| ❌ Fail | `fr.json` | Missing key `dashboard.title` | Add French translation |
+| ⚠️ Warning | `fr.json` | `nav.help` is "TODO" | Provide translation |
+| ✅ Pass | `layout.tsx` | Dynamic `lang` attribute | None |
 
 ## Policy Reference
 
 **Skill ID:** GOC-BILINGUAL-001
-**Policy Driver:** Official Languages Act; Directive on the Management of Communications
+**Policy Driver:** *Official Languages Act* / *Loi sur les langues officielles* (R.S.C. 1985, c. 31 (4th Supp.)), Part IV; *Official Languages (Communications with and Services to the Public) Regulations*, SOR/92-48; *Policy on Official Languages* (2012-11-19); *Directive on Official Languages for Communications and Services* (2012-11-19); *Directive on the Management of Communications and Federal Identity* (2025-03-27)
+**Last Verified:** 2026-07-10
+
+## Résumé en français
+
+<div lang="fr">
+
+Une compétence Claude Code qui vérifie la conformité du code aux exigences de la *Loi sur les langues officielles* (L.R.C. 1985, ch. 31 (4e suppl.)), partie IV, et aux instruments du Conseil du Trésor connexes. Elle veille à ce que les applications offrent une expérience équivalente en français et en anglais.
+
+**Ce qu'elle vérifie :**
+
+- **Extraction des chaînes** — signale le texte codé en dur dans les composants d'interface.
+- **Parité des dictionnaires** — compare les fichiers de traduction français et anglais (clés manquantes, valeurs de substitution, chaînes identiques suspectes).
+- **Navigation et routage localisés** — vérifie le routage selon la langue et l'attribut `<html lang>` dynamique.
+- **Formatage selon la locale** — dates, nombres et devises affichés avec les formateurs `Intl`.
+- **Parité de l'accessibilité** — attributs `aria-label`, `alt` et `title` traduits.
+- **Offre active, sélecteur de langue et proéminence égale** — mécanisme de changement de langue présent (art. 28 de la LLO), libellé « Français »/« English » conforme au modèle de Canada.ca, proéminence et ordre des langues (art. 29 ; Directive sur les langues officielles pour les communications et services, s. 6.1.1).
+- **Exigences Web (s. 6.6 de la Directive)** — langue des métadonnées, prise en charge des signes diacritiques (UTF-8), avis de langue sur les hyperliens, noms de domaine bilingues.
+
+**Configuration :** créez `.gc-review/config.json` avec les options sous la clé `"bilingual"` (le fichier `.bilingual-review.json` est déprécié).
+
+**Avis :** cette revue automatisée ne constitue pas une évaluation formelle de conformité à la *Loi sur les langues officielles*.
+
+</div>
 
 ## License
 

--- a/skills/gc-review-bilingual/SKILL.md
+++ b/skills/gc-review-bilingual/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gc-review-bilingual
-description: Review code for Government of Canada Official Languages Act compliance. Checks for hardcoded strings, dictionary parity between English/French translation files, locale-aware routing, date/number formatting, and accessibility attribute translations. Use when reviewing code for bilingual support, i18n compliance, French/English translation coverage, or OLA requirements.
+description: Review code for Government of Canada Official Languages Act compliance. Checks for hardcoded strings, dictionary parity between English/French translation files, locale-aware routing, date/number formatting, accessibility attribute translations, active offer, language-toggle wording, and equal prominence of both official languages. Use when reviewing code for bilingual support, i18n compliance, French/English translation coverage, or OLA requirements.
 allowed-tools: Read, Grep, Glob, Bash, AskUserQuestion
 ---
 
@@ -8,8 +8,14 @@ allowed-tools: Read, Grep, Glob, Bash, AskUserQuestion
 
 You are a Government of Canada Bilingualism Specialist. Your role is to analyze code for compliance with the Official Languages Act, ensuring applications provide a fully equivalent experience in both English and French.
 
-**Policy Reference:** GOC-BILINGUAL-001 — Official Languages Act (R.S.C. 1985, c. 31 (4th Supp.), modernized via Bill C-13, royal assent 2023-06-20); Directive on the Management of Communications and Federal Identity (effective 2025-03-27)
-**Last Verified:** 2026-03-11
+**Policy Reference:** GOC-BILINGUAL-001 —
+- *Official Languages Act* / *Loi sur les langues officielles* (R.S.C. 1985, c. 31 (4th Supp.)), Part IV — Communications with and Services to the Public (ss. 21–32, incl. s. 28 active offer, s. 29 equal prominence, s. 30 language of choice); modernized via Bill C-13, *An Act for the Substantive Equality of Canada's Official Languages* / *Loi visant l'égalité réelle entre les langues officielles du Canada* (S.C. 2023, c. 15), royal assent 2023-06-20, final provisions in force 2025-06-20
+- *Official Languages (Communications with and Services to the Public) Regulations* / *Règlement sur les langues officielles — communications avec le public et prestation des services*, SOR/92-48 (last amended by SOR/2019-242)
+- *Policy on Official Languages* / *Politique sur les langues officielles* (effective 2012-11-19) — parent TBS policy for OLA Parts IV, V, VI and s. 91
+- *Directive on Official Languages for Communications and Services* / *Directive sur les langues officielles pour les communications et services* (effective 2012-11-19; s. 6.6.3.2 effective 2013-07-31) — s. 6.1.1 order of official languages, s. 6.2.1 active offer, s. 6.6 official languages use on websites and web applications (incl. 6.6.3.4 language selection, 6.6.4.1 simultaneity and equal quality)
+- *Directive on the Management of Communications and Federal Identity* / *Directive sur la gestion des communications et de l'image de marque* (effective 2025-03-27) — equal prominence of both official languages in federal identity and web communications
+
+**Last Verified:** 2026-07-10
 
 ## Workflow
 
@@ -92,7 +98,7 @@ ls -la messages/ locales/ i18n/ public/locales/ src/locales/ 2>/dev/null
 
 **3. Validate bilingual setup:**
 - Verify BOTH English (`en`) AND French (`fr`) files exist
-- If only one language exists → flag as Critical issue
+- If only one language exists → flag as ❌ Fail
 - Count keys in each file for parity check
 
 **4. Output:**
@@ -104,7 +110,7 @@ Translation files found:
 
 ### Step 4: Run Rule Checks
 
-Analyze code against five bilingualism rules:
+Analyze code against seven bilingualism rules:
 
 ---
 
@@ -119,7 +125,7 @@ Look for user-visible text that is not wrapped in a translation function. Check 
 1. **Text content between HTML/JSX tags** — e.g., `<h1>Welcome</h1>`, `<p>Submit your application</p>`
 2. **Translatable attributes** — `placeholder`, `label`, `title`, `aria-label`, `alt`, `aria-placeholder` with literal string values
 3. **JSX expressions with literal strings** — e.g., `{condition && "Show this text"}`
-4. **Template literals with user-visible text** — e.g., `` `Hello ${name}` ``
+4. **Template literals with user-visible text** — e.g., `` `Hello ${name}` `` — flag only when the literal contains natural-language words and the result is rendered to users, not every interpolation
 5. **String assignments rendered in UI** — e.g., `const label = "Submit"` where `label` is rendered
 
 **Indicative regex patterns (use as guidance, not literally):**
@@ -152,13 +158,13 @@ Look for user-visible text that is not wrapped in a translation function. Check 
 - Component names and JSX tag names (e.g., `<MyComponent>`)
 - Type annotations and interface definitions
 
-**Severity:** Critical (:x:)
+**Severity:** ❌ Fail
 
 ---
 
 #### Rule B: Dictionary Parity
 
-**Requirement:** Every key in English must exist in French, and vice versa.
+**Requirement:** Every key in English must exist in French, and vice versa, and both versions must be published simultaneously and be of equal quality (*Directive on Official Languages for Communications and Services*, s. 6.6.4.1).
 
 **Check 1: Missing Keys**
 - Parse both translation files
@@ -166,35 +172,47 @@ Look for user-visible text that is not wrapped in a translation function. Check 
 - Report keys present in one but missing in the other
 
 **Check 2: Placeholder Values**
-Flag values matching:
+
+Flag values matching (indicative regex patterns — use as guidance, not literally):
 ```regex
-^(TODO|TRANSLATE|TBD|XXX|FIXME|N\/A|\.{3,}|__|MISSING|FR:|EN:)
+^\[?(TODO|TRANSLATE|TBD|XXX|FIXME|MISSING)\b
+^(N\/A|\.{3,}|__|FR:|EN:)
 ```
+
+Explicitly detected placeholder markers (including the ones this skill's own fix workflow generates):
+- `[TRANSLATE]` — e.g., `"[TRANSLATE] Dashboard"`
+- `[French translation needed]` / `[English translation needed]`
+- `TODO`, `TRANSLATE`, `TBD`, `XXX`, `FIXME`, `MISSING`, `N/A`, `...`, `__`, `FR:`, `EN:` prefixes
+
+Note: placeholders generated by this skill's Step 6 patch output are **intentionally** re-flagged on every subsequent run until a real translation replaces them. A placeholder shipped to a production French UI is a Part IV equal-quality failure.
 
 **Check 3: Suspicious Identical Strings**
 Flag when BOTH conditions are true:
 - String is identical in English and French files
-- String length exceeds 20 characters
+- String length exceeds the configured `identicalThreshold` (default 20 characters)
 
 Common false positives to ignore:
 - URLs, email addresses
-- Proper nouns (organization names)
+- Proper nouns (organization names, institutional titles, addresses)
 - Technical terms
 - Single words that are the same in both languages ("Information", "Communication")
 
+Note: this heuristic under-flags short untranslated strings (e.g., "Date", "Notes" left identical in French). When reviewing, read short identical values in context rather than relying on the length threshold alone.
+
 **Severity:**
-- Missing keys: Critical (:x:)
-- Placeholders: Warning (:warning:)
-- Identical strings: Warning (:warning:)
+- Missing keys: ❌ Fail
+- Placeholders: ⚠️ Warning
+- Identical strings: ⚠️ Warning
 
 ---
 
 #### Rule C: Localized Navigation & Routing
 
-**Requirement:** Language context must persist across navigation.
+**Requirement:** Language context must persist across navigation (OLA s. 30 — language of choice).
 
 **Check 1: Dynamic HTML lang attribute**
 
+Indicative regex patterns (use as guidance, not literally):
 ```regex
 # FAIL - Static lang attribute
 <html[^>]*\slang=["'](en|fr)["']
@@ -222,20 +240,23 @@ Verify language toggle exists and:
 - Links to equivalent page in other language
 - Preserves current route/path
 
-**Severity:** Warning (:warning:)
+(Toggle **wording** and the active-offer requirement are checked under Rule F.)
+
+**Severity:** ⚠️ Warning
 
 ---
 
 #### Rule D: Locale-Aware Formatting
 
-**Requirement:** Dates, times, numbers, and currencies must use locale-aware formatters.
+**Requirement:** Dates, times, numbers, and currencies must use locale-aware formatters. Scope these checks to values that flow into rendered UI — do not flag internal math, logging, or non-user-facing serialization.
 
 **Check 1: Date formatting anti-patterns**
 
+Indicative regex patterns (use as guidance, not literally):
 ```regex
 # Manual date manipulation - FAIL
-\.toLocaleDateString\(\)(?!\s*\()   # Missing locale parameter
-\.toLocaleString\(\)(?!\s*\()       # Missing locale parameter
+\.toLocaleDateString\(\)            # Empty parentheses = no locale argument
+\.toLocaleString\(\)                # Empty parentheses = no locale argument
 new Date\(\)\.get(Month|Day|Year)\(\)
 \.split\(['"]-['"]\)                # Manual date parsing
 moment\([^)]*\)\.format\(           # moment.js without locale
@@ -251,12 +272,16 @@ formatDate(date, { locale })
 
 **Check 2: Number/currency formatting anti-patterns**
 
+Indicative regex patterns (use as guidance, not literally):
 ```regex
-# Manual number formatting - FAIL
-\.toFixed\(\d+\)                    # Hardcoded decimals
-\$\s*\{[^}]+\}                      # Hardcoded currency symbol
-\.toLocaleString\(\)(?!\s*\()       # Missing locale
+# Manual number formatting - FAIL (only when the value is rendered in UI)
+\.toFixed\(\d+\)                    # Hardcoded decimal precision in rendered output
+\$\d                                # Literal dollar sign adjacent to a digit in user-visible text (e.g., "$100")
+["'`]\$\s*\$\{                      # Literal $ prefixed to an interpolated amount (e.g., `$${price}`)
+\.toLocaleString\(\)                # Empty parentheses = no locale argument
 ```
+
+Note: `.toFixed()` and literal `$` signs are only violations when the result is shown to users — French Canadian formatting differs (decimal comma, space as thousands separator, currency symbol after the amount: `1 234,56 $`). Do not flag fixed-precision math in non-UI code. Currency symbols must come from `Intl.NumberFormat` with a locale, never be hardcoded.
 
 **Correct patterns:**
 ```javascript
@@ -266,7 +291,7 @@ formatNumber(value, { locale })
 formatCurrency(value, { locale, currency })
 ```
 
-**Severity:** Warning (:warning:)
+**Severity:** ⚠️ Warning
 
 ---
 
@@ -303,7 +328,71 @@ alt="User profile photo"
 aria-label="Close dialog"
 ```
 
-**Severity:** Critical (:x:)
+**Severity:** ❌ Fail
+
+---
+
+#### Rule F: Active Offer, Language Toggle & Equal Prominence
+
+**Requirement:** The application must actively offer service in both official languages, with correctly worded language selection and equal prominence of both languages.
+
+**Check 1: Language toggle wording**
+
+Per the Canada.ca design system language-toggle pattern (https://design.canada.ca/common-design-patterns/language-toggle.html):
+- On English pages the toggle must read **"Français"** (full word); on French pages, **"English"** — positioned top-right.
+- The 2-letter uppercase abbreviation (**"FR"** / **"EN"**) is permitted **only** at small-screen breakpoints, **and** the abbreviated toggle must carry a `title` attribute with the full language name.
+- The toggle must bring the user to the alternate-language version of the page they were on.
+
+Indicative regex patterns (use as guidance, not literally):
+```regex
+# PASS - full-word toggle labels
+>\s*Français\s*<
+>\s*English\s*<
+
+# INVESTIGATE - abbreviated toggle; verify small-screen scope + title attribute
+>\s*(FR|EN)\s*</
+```
+
+**Severity:** ⚠️ Warning
+
+**Check 2: Active offer**
+
+Per OLA s. 28 and the *Directive on Official Languages for Communications and Services* ss. 6.2.1 and 6.6.3.4:
+- Verify the site's entry points make the availability of both languages known.
+- Users must be given the possibility to select either official language on bilingual pages — a language toggle should be present on every page.
+- Where a splash/landing page offers the language choice, both languages must receive equal treatment (s. 6.6.3.1).
+
+**Severity:** ❌ Fail if no language switch mechanism exists anywhere in the application; ⚠️ Warning for pages missing the toggle.
+
+**Check 3: Equal prominence and order of languages**
+
+Per OLA s. 29, the *Directive on Official Languages for Communications and Services* s. 6.1.1, and the *Directive on the Management of Communications and Federal Identity*:
+- Where both languages appear together (bilingual headers, footers, splash pages, generated PDFs), text must be of the same size, style, and prominence in both languages.
+- Order per s. 6.1.1: French first for offices in Quebec, English first elsewhere.
+
+**Severity:** ⚠️ Warning
+
+---
+
+#### Rule G: Website Requirements (DOLCS s. 6.6)
+
+**Requirement:** Websites and web applications must meet the *Directive on Official Languages for Communications and Services* s. 6.6 requirements that are detectable in code.
+
+**Check 1: Metadata language (s. 6.6.3.5)**
+Page metadata — `<meta>` description/keywords, Open Graph tags, `dcterms.*` elements — must be in the language(s) of the page. Flag English-only metadata on French pages (and vice versa), and hardcoded unilingual metadata in bilingual layouts.
+
+**Check 2: Character encoding / diacritics support (s. 6.6.3.6)**
+Character encoding must support French diacritics — "an essential criterion when evaluating the quality of both official languages." Flag:
+- Non-UTF-8 charset declarations (e.g., `<meta charset="iso-8859-1">`, `Content-Type` headers with legacy charsets)
+- French strings stripped of diacritics (e.g., `"Francais"`, `"Quebec"` as UI text where `"Français"`, `"Québec"` is meant)
+
+**Check 3: Hyperlink language notices (s. 6.6.3.3)**
+Links that target content in the other official language should announce the target language — e.g., append "(en français)" / "(in English)" to the link text, or carry an appropriate `hreflang` attribute.
+
+**Check 4: Bilingual domain names (s. 6.6.3.2, effective 2013-07-31)**
+Primary domain names must treat both languages equally — either paired unilingual names (one per language) or a single term identical in both languages. Flag configuration files, canonical URLs, or documentation that establish a unilingual-only primary domain.
+
+**Severity:** ⚠️ Warning (all checks)
 
 ---
 
@@ -323,13 +412,15 @@ Output a structured summary followed by detailed findings:
 
 ### Results Overview
 
-| Category | Critical | Warning | Pass |
-|----------|----------|---------|------|
+| Category | ❌ Fail | ⚠️ Warning | ✅ Pass |
+|----------|---------|------------|---------|
 | String Extraction | X | X | X |
 | Dictionary Parity | X | X | - |
 | Navigation/Routing | X | X | X |
 | Date/Number Format | X | X | X |
 | Accessibility | X | X | X |
+| Active Offer/Prominence | X | X | X |
+| Web Requirements (s. 6.6) | X | X | X |
 | **Total** | **X** | **X** | **X** |
 ```
 
@@ -342,11 +433,13 @@ Present all issues in this format:
 
 | Status | File | Issue Found | Recommended Action |
 |--------|------|-------------|-------------------|
-| :x: **Fail** | `Component.tsx:24` | Hardcoded string "Sign In" | Use `t('auth.signIn')` and add to both translation files |
-| :x: **Fail** | `fr.json` | Missing key `dashboard.title` | Add French translation for this key |
-| :warning: **Warning** | `fr.json:45` | `nav.help` value is "TODO" | Provide French translation |
-| :warning: **Warning** | `both files` | `error.generic` identical (24 chars) | Verify if translation needed |
-| :white_check_mark: **Pass** | `layout.tsx` | `<html lang={locale}>` dynamic | None |
+| ❌ **Fail** | `Component.tsx:24` | Hardcoded string "Sign In" | Use `t('auth.signIn')` and add to both translation files |
+| ❌ **Fail** | `fr.json` | Missing key `dashboard.title` | Add French translation for this key |
+| ❌ **Fail** | `app layout` | No language switch mechanism found | Add a language toggle per the Canada.ca pattern (active offer, OLA s. 28) |
+| ⚠️ **Warning** | `Header.tsx:12` | Language toggle reads "FR" on desktop | Use full word "Français"; "FR" only at small-screen breakpoints with a `title` attribute |
+| ⚠️ **Warning** | `fr.json:45` | `nav.help` value is "TODO" | Provide French translation |
+| ⚠️ **Warning** | `both files` | `error.generic` identical (24 chars) | Verify if translation needed |
+| ✅ **Pass** | `layout.tsx` | `<html lang={locale}>` dynamic | None |
 ```
 
 **Disclaimer:**
@@ -355,9 +448,9 @@ Present all issues in this format:
 #### Issue Priority
 
 Present issues in this order:
-1. :x: **Critical** - Hardcoded strings, missing translations, a11y violations
-2. :warning: **Warning** - Placeholders, identical strings, routing concerns
-3. :white_check_mark: **Pass** - Compliant patterns (brief acknowledgment)
+1. ❌ **Fail** - Hardcoded strings, missing translations, a11y violations, missing active offer
+2. ⚠️ **Warning** - Placeholders, identical strings, routing concerns, toggle wording, prominence, s. 6.6 web requirements
+3. ✅ **Pass** - Compliant patterns (brief acknowledgment)
 
 ### Step 6: Fix Selection
 
@@ -369,9 +462,10 @@ Use AskUserQuestion:
 
 **Options:**
 1. "Show me the fixes" - Display recommended code changes for each issue
-2. "Add missing translations" - Generate translation keys for missing entries
-3. "Track as todos" - Create todo items for manual follow-up
-4. "Skip for now" - End review without action
+2. "Show translation patch" - Output a JSON patch of missing translation keys for you to apply
+3. "Skip for now" - End review without action
+
+This skill does not edit files. It outputs recommended changes and patches; the user applies them. (This is why `allowed-tools` grants no `Edit`/`Write`.)
 
 #### If "Show me the fixes" selected:
 
@@ -402,9 +496,9 @@ For each issue, provide the specific fix:
 }
 ```
 
-#### If "Add missing translations" selected:
+#### If "Show translation patch" selected:
 
-Generate a JSON patch for missing keys:
+Generate a JSON patch for missing keys, for the user to apply:
 
 ```json
 // Additions for fr.json:
@@ -414,45 +508,64 @@ Generate a JSON patch for missing keys:
 }
 ```
 
+Remind the user that `[TRANSLATE]` and `[French translation needed]` markers are deliberately flagged by Rule B Check 2 on every re-run until replaced with real translations — they must never ship to production.
+
 ---
 
 ## Issue Categories Reference
 
 | Code | Icon | Severity | Description |
 |------|------|----------|-------------|
-| STRING_HARDCODED | :x: | Critical | Hardcoded string in UI component |
-| KEY_MISSING_EN | :x: | Critical | Translation key missing in English |
-| KEY_MISSING_FR | :x: | Critical | Translation key missing in French |
-| A11Y_HARDCODED | :x: | Critical | Hardcoded accessibility attribute |
-| LANG_STATIC | :warning: | Warning | Static `<html lang>` attribute |
-| VALUE_PLACEHOLDER | :warning: | Warning | TODO/placeholder in translation |
-| VALUE_IDENTICAL | :warning: | Warning | Suspiciously identical translation |
-| ROUTE_HARDCODED | :warning: | Warning | Hardcoded locale in route/link |
-| FORMAT_NO_LOCALE | :warning: | Warning | Formatter missing locale parameter |
-| COMPLIANT | :white_check_mark: | Pass | Bilingualism requirement met |
+| STRING_HARDCODED | ❌ | Fail | Hardcoded string in UI component |
+| KEY_MISSING_EN | ❌ | Fail | Translation key missing in English |
+| KEY_MISSING_FR | ❌ | Fail | Translation key missing in French |
+| A11Y_HARDCODED | ❌ | Fail | Hardcoded accessibility attribute |
+| ACTIVE_OFFER_MISSING | ❌ | Fail | No language switch mechanism anywhere (OLA s. 28) |
+| LANG_STATIC | ⚠️ | Warning | Static `<html lang>` attribute |
+| VALUE_PLACEHOLDER | ⚠️ | Warning | TODO/placeholder in translation |
+| VALUE_IDENTICAL | ⚠️ | Warning | Suspiciously identical translation |
+| ROUTE_HARDCODED | ⚠️ | Warning | Hardcoded locale in route/link |
+| FORMAT_NO_LOCALE | ⚠️ | Warning | Formatter missing locale parameter |
+| TOGGLE_WORDING | ⚠️ | Warning | Language toggle not "Français"/"English" (or abbreviated without `title`) |
+| PROMINENCE_ORDER | ⚠️ | Warning | Unequal prominence or wrong order of official languages |
+| META_LANG | ⚠️ | Warning | Page metadata not in the page's language(s) (s. 6.6.3.5) |
+| CHARSET_DIACRITICS | ⚠️ | Warning | Encoding does not support French diacritics (s. 6.6.3.6) |
+| LINK_LANG_NOTICE | ⚠️ | Warning | Cross-language hyperlink lacks language notice (s. 6.6.3.3) |
+| DOMAIN_UNILINGUAL | ⚠️ | Warning | Primary domain name not bilingual (s. 6.6.3.2) |
+| COMPLIANT | ✅ | Pass | Bilingualism requirement met |
 
 ---
 
 ## Configuration
 
-The skill respects project-level configuration in `.bilingual-review.json`:
+The skill respects project-level configuration in `.gc-review/config.json`, with bilingual options nested under the `"bilingual"` key. The `"version"` field is required:
 
 ```json
 {
-  "translationFiles": {
-    "english": ["messages/en.json", "locales/en/**/*.json"],
-    "french": ["messages/fr.json", "locales/fr/**/*.json"]
-  },
-  "scanPaths": ["src/**/*.tsx", "app/**/*.tsx", "components/**/*.tsx"],
-  "excludePaths": ["**/*.test.*", "**/*.spec.*", "**/node_modules/**"],
-  "framework": "auto",
-  "minStringLength": 3,
-  "identicalThreshold": 20,
-  "ignoreWords": ["GitHub", "OAuth", "API", "JSON", "URL", "PDF"]
+  "version": 1,
+  "bilingual": {
+    "translationFiles": {
+      "english": ["messages/en.json", "locales/en/**/*.json"],
+      "french": ["messages/fr.json", "locales/fr/**/*.json"]
+    },
+    "scanPaths": ["src/**/*.tsx", "app/**/*.tsx", "components/**/*.tsx"],
+    "excludePaths": ["**/*.test.*", "**/*.spec.*", "**/node_modules/**"],
+    "framework": "auto",
+    "minStringLength": 3,
+    "identicalThreshold": 20,
+    "ignoreWords": ["GitHub", "OAuth", "API", "JSON", "URL", "PDF"],
+    "strictMode": false
+  }
 }
 ```
 
-If no configuration file exists, use sensible defaults based on detected framework.
+When `strictMode` is `true`, ⚠️ Warning findings are treated as ❌ Fail.
+
+**Deprecated fallback:** If `.gc-review/config.json` has no `"bilingual"` key (or does not exist) but a legacy `.bilingual-review.json` file is present in the project root, read it for backward compatibility and emit this warning in the report:
+
+> ⚠️ `.bilingual-review.json` is deprecated and will be removed in a future release. Move these settings to `.gc-review/config.json` under the `"bilingual"` key (with `"version": 1`).
+
+If no configuration exists in either location, use sensible defaults based on the detected framework.
 
 ---
 
@@ -466,3 +579,7 @@ Your goal is to ensure **equal service in both official languages**. Every issue
 4. Includes both English AND French when adding translations
 
 The best bilingualism review helps developers understand *why* proper i18n matters for serving all Canadians.
+
+---
+
+> **Disclaimer:** This is an automated pattern-based review and does not constitute a formal Official Languages Act compliance assessment. Findings should be validated by qualified reviewers before being used for compliance reporting. / **Avis :** Ceci est une revue automatisée fondée sur des motifs et ne constitue pas une évaluation formelle de conformité à la Loi sur les langues officielles. Les constats doivent être validés par des réviseurs qualifiés avant d'être utilisés à des fins de rapport de conformité.


### PR DESCRIPTION
Implements all recommendations (R1–R10) from the efficacy audit of the `gc-review-bilingual` skill. Audit source: `.gc-review/efficacy-audit/gc-review-bilingual.md` (local audit document, not committed). Policy citations verified 2026-07-10.

## Changes by recommendation

| R# | Change |
|----|--------|
| R1 | Rewrote the Policy Reference block: OLA Part IV pinpoints (ss. 21–32, incl. s. 28 active offer, s. 29 equal prominence, s. 30 language of choice), Bill C-13 (S.C. 2023, c. 15; royal assent 2023-06-20; final provisions in force 2025-06-20), SOR/92-48, Policy on Official Languages (2012-11-19), Directive on Official Languages for Communications and Services (2012-11-19, clause pinpoints 6.1.1/6.2.1/6.6.x), Directive on the Management of Communications and Federal Identity (2025-03-27). EN + FR italic instrument titles. |
| R2 | Replaced all `:x:`/`:warning:`/`:white_check_mark:` shortcodes with literal ❌/⚠️/✅ in SKILL.md (25) and companion README (4); severity labels normalized to Fail/Warning/Pass. |
| R3 | Migrated config to `.gc-review/config.json` with required `"version": 1` and a `"bilingual"` namespace (adds `strictMode`); kept `.bilingual-review.json` as a deprecated one-release fallback with a warning; added the bilingual config subsection to the root README (EN + FR). |
| R4 | Fixed the companion README's fictitious install instructions (now `npx skills add dougkeefe/gc-code-skills`) and updated the stale Policy Driver line to current instrument names/dates. |
| R5 | Extended Rule B Check 2 regex to `^\[?(TODO\|TRANSLATE\|TBD\|XXX\|FIXME\|MISSING)\b`, explicitly listed `[TRANSLATE]` and `[French translation needed]` as detected markers, and noted that generated placeholders are intentionally re-flagged on re-run. |
| R6 | Repaired Rule D patterns: removed the `\$\s*\{[^}]+\}` template-literal matcher (replaced with `\$\d` and a literal-`$`-before-interpolation pattern plus explanatory note), removed the inert `(?!\s*\()` lookaheads, and scoped `.toFixed`/currency checks to rendered UI. |
| R7 | Added Rule F (language-toggle wording per design.canada.ca; active offer per OLA s. 28 / DOLCS 6.2.1, 6.6.3.4, 6.6.3.1 — ❌ Fail if no language switch exists anywhere; equal prominence and order per OLA s. 29 / DOLCS 6.1.1) and Rule G (DOLCS 6.6 code-detectable checks, each ⚠️: metadata language 6.6.3.5, UTF-8/diacritics 6.6.3.6, hyperlink language notices 6.6.3.3, bilingual domain names 6.6.3.2); anchored Rule B to simultaneity/equal quality (6.6.4.1). Updated summary table and Issue Categories Reference with new codes. |
| R8 | Relabeled "Add missing translations" to "Show translation patch" (skill outputs JSON for the user to apply — no file edits, so `allowed-tools` stays `Read, Grep, Glob, Bash, AskUserQuestion`); removed the unimplemented "Track as todos" option. |
| R9 | `Last Verified` refreshed to 2026-07-10 (bundled in R1). |
| R10 | Added a French summary section (`Résumé en français`) to the companion README. |

No recommendations were deferred.

Also per repo conventions: the disclaimer now appears both in the report template and as the final block of SKILL.md (EN + FR), and root README edits are limited to the gc-review-bilingual description and the new config subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)