### PR TITLE
gc-review-security: implement efficacy-audit recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ Vérifie la conformité du code au niveau AA des WCAG 2.2. Contrôle le HTML sé
 </div>
 
 ### `gc-review-security`
-Reviews code for Protected B security compliance. Evaluates access control, input validation, encryption, secrets management, and logging against ITSG-33 controls.
+Reviews code for Protected B security compliance. Evaluates access control, input validation, PII handling, cryptography (per CCCS ITSP.40.111 v5, including post-quantum milestones), security headers, secrets management, and audit logging against ITSG-33 controls and GC web configuration requirements.
 
 <div lang="fr">
 
-Vérifie la conformité du code aux exigences de sécurité Protégé B. Évalue le contrôle d'accès, la validation des entrées, le chiffrement, la gestion des secrets et la journalisation selon les contrôles ITSG-33.
+Vérifie la conformité du code aux exigences de sécurité Protégé B. Évalue le contrôle d'accès, la validation des entrées, le traitement des renseignements personnels, la cryptographie (selon l'ITSP.40.111 v5 du CCC, y compris les jalons post-quantiques), les en-têtes de sécurité, la gestion des secrets et la journalisation d'audit selon les contrôles ITSG-33 et les exigences de configuration Web du GC.
 
 </div>
 
@@ -142,6 +142,29 @@ EOF
 ```
 
 ### Supported configuration by skill / <span lang="fr">Configuration prise en charge par compétence</span>
+
+#### `gc-review-security`
+
+Options are namespaced under a `"security"` key:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `security.piiMetadataConvention` | `string[]` | unset | Annotation names the project uses to mark PII fields (e.g., `isPII`, `@Sensitive`). If unset, missing PII metadata is a warning instead of a failure. |
+| `security.auditLogService` | `string` | unset | Identifier of the sanctioned audit logging service. If unset, console logging of security events is a warning, not a failure. |
+| `security.approvedAlgorithmExceptions` | `string[]` | `[]` | Algorithms with a documented, assessor-approved exception; findings are downgraded to warnings. |
+| `security.strictMode` | `boolean` | `false` | When true, warnings are treated as failures. |
+
+```json
+{
+  "version": 1,
+  "security": {
+    "piiMetadataConvention": ["isPII"],
+    "auditLogService": "auditLog"
+  }
+}
+```
+
+See [`skills/gc-review-security/CONFIG.md`](skills/gc-review-security/CONFIG.md) for the full schema.
 
 #### `gc-review-iam`
 

--- a/skills/gc-review-security/CONFIG.md
+++ b/skills/gc-review-security/CONFIG.md
@@ -1,0 +1,231 @@
+# gc-review-security Configuration
+
+This document describes the configuration schema for the `gc-review-security` skill.
+
+## Configuration File Location
+
+**Project config:**
+```
+.gc-review/config.json
+```
+
+If no config exists, default settings are used. All `gc-review-security` options live under the `"security"` namespace so the file can be shared with other skills.
+
+---
+
+## Configuration Schema
+
+```json
+{
+  "version": 1,
+  "security": {
+    "piiMetadataConvention": ["isPII", "@PII", "@Sensitive"],
+    "auditLogService": "auditLog",
+    "approvedAlgorithmExceptions": [],
+    "strictMode": false
+  }
+}
+```
+
+---
+
+## Field Definitions
+
+### version
+**Type:** `number`
+**Required:** Yes
+**Description:** Configuration schema version. Currently `1`. Top-level field shared by all gc-review skills.
+
+```json
+{
+  "version": 1
+}
+```
+
+---
+
+### security.piiMetadataConvention
+**Type:** `string[]`
+**Required:** No
+**Default:** unset
+**Description:** Annotation/metadata names the project uses to mark PII fields (e.g., `isPII`, `@PII`, `@Sensitive`). Marking PII with metadata is a project convention that supports Privacy Act obligations — the *Privacy Act* does not mandate code-level annotations.
+
+**Severity effect (rule C):**
+- **Set:** PII fields missing one of these annotations → ❌ **Fail**
+- **Unset:** PII fields without protective metadata → ⚠️ **Warning** (recommend adopting a convention)
+
+```json
+{
+  "version": 1,
+  "security": {
+    "piiMetadataConvention": ["isPII", "@Sensitive"]
+  }
+}
+```
+
+---
+
+### security.auditLogService
+**Type:** `string`
+**Required:** No
+**Default:** unset
+**Description:** Identifier (function, module, or service name) of the project's sanctioned audit logging service.
+
+**Severity effect (rule E):**
+- **Set:** security events that bypass this service (e.g., raw `console.log`) → ❌ **Fail**
+- **Unset:** console/stdout logging of security events → ⚠️ **Warning** only (stdout-to-SIEM pipelines are standard in containerized deployments; verify forwarding to an approved GC centralized SIEM)
+
+```json
+{
+  "version": 1,
+  "security": {
+    "auditLogService": "auditLog"
+  }
+}
+```
+
+---
+
+### security.approvedAlgorithmExceptions
+**Type:** `string[]`
+**Required:** No
+**Default:** `[]`
+**Description:** Algorithm identifiers with a documented, assessor-approved exception (e.g., a legacy interoperability requirement). Findings involving these algorithms are downgraded from ❌ **Fail** to ⚠️ **Warning**, with a note referencing the exception. This does not exempt the project from ITSP.40.111 phase-out timelines.
+
+```json
+{
+  "version": 1,
+  "security": {
+    "approvedAlgorithmExceptions": ["3DES"]
+  }
+}
+```
+
+---
+
+### security.strictMode
+**Type:** `boolean`
+**Required:** No
+**Default:** `false`
+**Description:** When enabled, all ⚠️ **Warning** findings are reported as ❌ **Fail**.
+
+```json
+{
+  "version": 1,
+  "security": {
+    "strictMode": true
+  }
+}
+```
+
+---
+
+## Complete Example Configurations
+
+### Minimal Project Config
+
+```json
+{
+  "version": 1,
+  "security": {
+    "piiMetadataConvention": ["isPII"]
+  }
+}
+```
+
+### Full Project Config
+
+```json
+{
+  "version": 1,
+  "security": {
+    "piiMetadataConvention": ["isPII", "@PII", "@Sensitive"],
+    "auditLogService": "SecurityAuditLogger",
+    "approvedAlgorithmExceptions": [],
+    "strictMode": false
+  }
+}
+```
+
+### Strict Government Production Config
+
+```json
+{
+  "version": 1,
+  "security": {
+    "piiMetadataConvention": ["isPII"],
+    "auditLogService": "auditLog",
+    "strictMode": true
+  }
+}
+```
+
+---
+
+## Validation Rules
+
+### File Existence
+1. Check if `.gc-review/config.json` exists
+2. If missing, use defaults
+
+### JSON Validation
+```bash
+# Validate JSON syntax
+jq empty .gc-review/config.json 2>&1
+```
+
+If invalid JSON:
+```
+⚠️  Invalid JSON in .gc-review/config.json: {error}
+Using default configuration.
+```
+
+### Field Validation
+
+| Field | Validation |
+|-------|------------|
+| `version` | Must be number, currently `1` |
+| `security.piiMetadataConvention` | Must be array of strings |
+| `security.auditLogService` | Must be string |
+| `security.approvedAlgorithmExceptions` | Must be array of strings |
+| `security.strictMode` | Must be boolean |
+
+### Invalid Field Handling
+
+If a field has invalid type:
+```
+⚠️  Invalid config: {field} must be {expected_type}, got {actual_type}
+Using default value for {field}.
+```
+
+### Unknown Field Handling
+
+Unknown fields under `security` are ignored with a warning:
+```
+⚠️  Unknown config field: security.{field_name} (ignored)
+```
+
+---
+
+## Config Resolution
+
+```
+.gc-review/config.json exists → use "security" namespace from project config
+.gc-review/config.json missing → use default configuration
+```
+
+---
+
+## Setting Up Configuration
+
+```bash
+mkdir -p .gc-review
+cat > .gc-review/config.json << 'EOF'
+{
+  "version": 1,
+  "security": {
+    "piiMetadataConvention": ["isPII"]
+  }
+}
+EOF
+```

--- a/skills/gc-review-security/SKILL.md
+++ b/skills/gc-review-security/SKILL.md
@@ -1,24 +1,41 @@
 ---
 name: gc-review-security
-description: "Use when reviewing code changes for Protected B security compliance. Triggers: security review, ITSG-33 compliance, GoC security, Protected B data handling, access control review, PII protection check, or requests to audit security-sensitive code."
-allowed-tools: Read, Grep, Glob
+description: Review code changes for Government of Canada Protected B security compliance. Checks access control, input validation, PII handling, cryptography, security headers, secrets management, and audit logging against ITSG-33 controls, CCCS cryptographic guidance, and the Privacy Act.
+allowed-tools: Read, Grep, Glob, Bash
 ---
 
 # Protected B Security Reviewer
 
 Act as a **GoC Cyber Security Specialist** for Protected B applications. Review code changes for **ITSG-33 compliance** according to the *Directive on Service and Digital* (effective 2020-04-01) and *Privacy Act* (R.S.C. 1985, c. P-21) requirements.
 
-**Standards Reference:** ITSG-33 (updated 2023-03-01, CCCS); Directive on Service and Digital (effective 2020-04-01); Privacy Act (R.S.C. 1985, c. P-21)
-**Last Verified:** 2026-03-11
+**Standards Reference:**
+- ITSG-33 — *IT Security Risk Management: A Lifecycle Approach* / *La gestion des risques liés à la sécurité des TI : Une méthode axée sur le cycle de vie* (CCCS, effective 2012-11-01; Annex 3A Security Control Catalogue, December 2014, aligned with NIST SP 800-53 rev. 4)
+- ITSP.40.111 — *Cryptographic Algorithms for UNCLASSIFIED, PROTECTED A, and PROTECTED B Information* / *Algorithmes cryptographiques pour l'information NON CLASSIFIÉ, PROTÉGÉ A et PROTÉGÉ B* (CCCS, v5, effective 2026-05-29)
+- ITSP.40.062 — *Guidance on Securely Configuring Network Protocols* / *Conseils sur la configuration sécurisée des protocoles réseau* (CCCS, v3, January 2025)
+- Directive on Service and Digital / *Directive sur les services et le numérique* (TBS, effective 2020-04-01; minor amendments 2025-08-29)
+- Privacy Act / *Loi sur la protection des renseignements personnels* (R.S.C. 1985, c. P-21; last amended 2025-06-02)
+
+**Last Verified:** 2026-07-10
+
+Web-facing checks in section F are sourced from the GC *Web Sites and Services Management Configuration Requirements* / *Exigences de configuration de la gestion des sites Web et des services* (Date modified 2024-10-25); requirement numbers (e.g., req. 2.4) refer to that instrument.
 
 ## Review Process
 
-1. Analyze the code changes provided (diff, files, or codebase areas specified by the user)
-2. Evaluate each file against the 5-point security checklist below
-3. Categorize findings by ITSG-33 control family
-4. Output a structured findings table
+1. **Detect changed files:** run `git diff --name-only main...HEAD` (or the base branch/range specified by the user) via Bash. If the project is not a git repository or the user has provided an explicit diff, file list, or scope, use that instead.
+2. **Load configuration:** if `.gc-review/config.json` exists, read options under the `"security"` namespace (see [CONFIG.md](./CONFIG.md)). If absent, use the defaults described there.
+3. Evaluate each changed file against the 6-point security checklist below
+4. Categorize findings by ITSG-33 control family
+5. Output a structured findings table
 
-Refer to [checklist.md](./checklist.md) for detailed patterns and [report-template.md](./report-template.md) for output format.
+Refer to [checklist.md](./checklist.md) for detailed patterns and [report-template.md](./report-template.md) for output format. All detection patterns are indicative, not literal regex — read the surrounding code for context before flagging.
+
+**Inline flag severity mapping** (deterministic):
+- `[Security Error: XX]` → ❌ **Fail**
+- `[Security Warning: XX]` → ⚠️ **Warning**
+
+If `security.strictMode` is `true` in config, ⚠️ Warnings are reported as ❌ Fail.
+
+**Scope note — IA family:** Authentication strength, MFA (ITSP.30.031 assurance levels), credential and authenticator management (ITSG-33 IA family, e.g., IA-5), OIDC, and session lifecycle are covered by the sibling skill **`gc-review-iam`**. Do not duplicate IA checks here; refer users to that skill for identification and authentication findings.
 
 ---
 
@@ -42,57 +59,74 @@ Refer to [checklist.md](./checklist.md) for detailed patterns and [report-templa
 
 ### B. Input Validation & Sanitization [ITSG-33: SI Family]
 
-**Rule:** All external inputs (request body, query params, headers) must be validated against a strict schema.
+**Rule:** All external inputs (request body, query params, headers) must be validated against a strict schema, and untrusted data must never drive code execution, deserialization, or outbound requests.
 
 **Check for:**
 - Schema validation library or framework validation on all inputs
 - Parameterized queries for database operations
 - No raw SQL or query-string concatenation
+- Server-Side Request Forgery (SSRF): outbound request URLs built from user input without allow-listing
+- Insecure deserialization: `pickle.loads`, `ObjectInputStream`, `yaml.load` without a safe loader, or equivalent on untrusted data
 
 **Flag as `[Security Error: SI]` if:**
 - Input used without validation
 - String concatenation in SQL/queries
 - Missing schema definition for request handlers
+- Outbound request target (URL, host, port) derived from unvalidated user input (SSRF)
+- Untrusted data passed to an unsafe deserializer
 
 ---
 
 ### C. Data Handling & Privacy [Privacy Act]
 
-**Rule:** Personally Identifiable Information (PII) must be explicitly flagged and protected.
+**Rule:** Personally Identifiable Information (PII) must be identified and protected. Marking PII fields with metadata is a **project convention that supports Privacy Act obligations** (collection limitation, purpose specification, data minimization, individual access rights under ss. 4–8 and 12) — the *Privacy Act* itself does not mandate code-level annotations.
 
 **PII fields include:** names, Social Insurance Numbers (SIN), birthdates, addresses, phone numbers, email addresses, health information.
 
 **Check for:**
-- PII fields marked with metadata (e.g., `isPII: true`, `@PII` decorator, or equivalent)
+- PII fields marked with the project's metadata convention (`security.piiMetadataConvention` in config; e.g., `isPII: true`, `@PII` decorator, or equivalent)
 - No PII in log statements
 - Appropriate masking/redaction in error messages
 
 **Flag as `[Security Error: PII]` if:**
-- PII fields lack protective metadata
 - Logging statements include user objects or PII fields
 - Error responses expose PII
+- PII fields lack protective metadata **and** `security.piiMetadataConvention` is configured for the project
+
+**Flag as `[Security Warning: PII]` if:**
+- PII fields lack protective metadata and no `security.piiMetadataConvention` is configured (recommend adopting a convention)
 
 ---
 
 ### D. Cryptography & Transmission [ITSG-33: SC Family]
 
-**Rule:** Protected B data must be encrypted in transit and at rest using approved algorithms.
+**Rule:** Protected B data must be encrypted in transit and at rest using CCCS-approved algorithms per ITSP.40.111 v5 and ITSP.40.062 v3.
 
 **Check for:**
-- TLS 1.2+ configuration
-- FIPS-validated cryptographic algorithms
+- TLS 1.2 minimum, TLS 1.3 preferred (ITSP.40.062 v3)
+- CCCS-approved cryptographic algorithms (see the crypto table in [checklist.md](./checklist.md), including post-quantum milestones from ITSP.40.111 v5)
 - Secure cookie configuration
+- Secrets management: no hardcoded credentials, no committed `.env` files, no keys in git history
 
 **Flag as `[Security Error: SC]` if:**
-- Weak algorithms used (MD5, SHA-1 for security purposes)
-- Cookies missing `HttpOnly`, `Secure`, or `SameSite: Strict` flags
-- Hardcoded secrets or credentials
+- Prohibited algorithms used: MD5 for any security purpose; SHA-1 with digital signature schemes; DES, 3DES, RC4
+- RSA or DH with keys shorter than 2048 bits
+- Cookies missing `HttpOnly`, `Secure`, or a `SameSite` attribute (`Strict` or `Lax`)
+- Hardcoded secrets or credentials, committed `.env` files, or keys present in git history (check with `git log --diff-filter=A -- '*.env' '*.pem' '*.key'`)
+- Algorithm appears in `security.approvedAlgorithmExceptions` → downgrade that finding to ⚠️ and note the documented exception
+
+**Flag as `[Security Warning: SC]` if:**
+- `SameSite=None` without documented justification
+- New code introduces quantum-vulnerable-only key establishment (no PQC path): ITSP.40.111 v5 requires key-establishment implementations to support post-quantum cryptography (ML-KEM) by **end of 2026**, with quantum-vulnerable RSA key establishment phased out by end of 2035
+- RSA/DH keys of 2048–3071 bits in new code (ITSP.40.111 v5 requires ≥ 3072 bits by end of 2030)
+
+**Attribution note:** cookie-attribute rules (`HttpOnly`, `Secure`, `SameSite`) are OWASP/industry best practice supporting ITSG-33 **SC-23 (Session Authenticity)** — no GC configuration instrument mandates specific cookie attributes. Secondary guidance: GC HTTPS Everywhere implementation guidance.
 
 ---
 
 ### E. Audit Logging [ITSG-33: AU Family]
 
-**Rule:** All security-significant events must be logged for the SIEM.
+**Rule:** All security-significant events must be logged and forwarded to an approved GC centralized SIEM, per the GC Event Logging Guidance (GC web configuration req. 4.3).
 
 **Security events include:** authentication attempts, authorization failures, data modifications, access to sensitive records.
 
@@ -101,12 +135,42 @@ Refer to [checklist.md](./checklist.md) for detailed patterns and [report-templa
 **Check for:**
 - Audit log calls on security events
 - Complete log entries with required fields
-- Centralized logging service usage
+- Centralized logging service usage, or a stdout/stderr pipeline that is forwarded to a SIEM (standard in containerized deployments)
 
 **Flag as `[Security Error: AU]` if:**
 - Security-significant action has no audit log
 - Log entries missing required fields
-- Logging directly to console instead of audit service
+- `security.auditLogService` is configured and security events bypass it (e.g., raw `console.log` instead of the sanctioned service)
+
+**Flag as `[Security Warning: AU]` if:**
+- Security events are logged to console/stdout and no `security.auditLogService` is configured — verify the deployment forwards stdout to an approved GC centralized SIEM before treating this as compliant
+
+---
+
+### F. Web Configuration & Security Headers [ITSG-33: SC Family / GC Web Configuration Requirements]
+
+**Rule:** GC web applications must enforce HTTPS and serve the mandated security response headers per the GC *Web Sites and Services Management Configuration Requirements* (2024-10-25).
+
+**Check for:**
+- HTTPS-only with HTTP→HTTPS redirect (req. 1.1)
+- HSTS enabled (req. 1.2)
+- Mandated response headers: **Content-Security-Policy**, **Strict-Transport-Security (HSTS)**, and **X-Frame-Options** (req. 2.4). `X-Content-Type-Options: nosniff` is a best-practice extra, not part of the mandated list.
+- Output encoding on all output (req. 2.3)
+- OWASP ASVS used as the application security verification baseline for web application development (req. 2.5)
+- A published `security.txt` (req. 4.5)
+- CSRF protection beyond cookie flags (anti-CSRF tokens or framework CSRF middleware) [SC family]
+
+**Flag as `[Security Error: WEB]` if:**
+- Web/server configuration in scope serves HTTP without redirecting to HTTPS
+- HSTS absent from a production web configuration
+- Any of the mandated headers (Content-Security-Policy, HSTS, X-Frame-Options) missing from web application responses
+- Output rendered without encoding/escaping (template engines with escaping disabled, `dangerouslySetInnerHTML` with unsanitized data)
+- State-changing endpoints lack CSRF protection
+
+**Flag as `[Security Warning: WEB]` if:**
+- `X-Content-Type-Options: nosniff` not set (best practice)
+- No published `security.txt` for a public-facing GC site (req. 4.5)
+- No evidence of OWASP ASVS alignment for web application code (req. 2.5)
 
 ---
 
@@ -129,7 +193,7 @@ Present findings in a markdown table:
 - ⚠️ **Warning** - Should address; potential risk
 - ✅ **Pass** - Compliant with requirements
 
-Include the ITSG-33 control family reference (AC, SI, SC, AU) or Privacy Act reference for each finding.
+Include the ITSG-33 control family reference (AC, SI, SC, AU, WEB) or Privacy Act reference for each finding. For identification and authentication (IA family) findings, refer users to `gc-review-iam` instead of reporting them here.
 
 End every report with:
 

--- a/skills/gc-review-security/checklist.md
+++ b/skills/gc-review-security/checklist.md
@@ -2,6 +2,10 @@
 
 Detailed patterns and guidance for ITSG-33 compliance review. This checklist is language-agnostic and applies to any technology stack.
 
+> **Note:** All patterns below are indicative, not literal regex — read the surrounding code for context before flagging.
+
+**Scope note:** Identification and authentication checks (ITSG-33 IA family — MFA, credential management, OIDC, session lifecycle) are covered by the sibling skill `gc-review-iam` and are intentionally not duplicated here.
+
 ---
 
 ## A. Broken Access Control [AC Family]
@@ -58,6 +62,15 @@ Detailed patterns and guidance for ITSG-33 compliance review. This checklist is 
 - SQL escaping handled by framework
 - Command injection prevention
 
+**SSRF Prevention:**
+- Outbound request URLs, hosts, or ports built from user input
+- Missing allow-list for user-influenced request targets
+- Redirect-following on user-supplied URLs
+
+**Deserialization Safety:**
+- Untrusted data passed to native deserializers
+- YAML/XML loaders without safe mode
+
 ### Common Patterns to Flag
 
 | Pattern | Risk | Fix |
@@ -66,6 +79,8 @@ Detailed patterns and guidance for ITSG-33 compliance review. This checklist is 
 | Request body used directly without validation | Malformed data, injection | Add schema validation |
 | `exec(userInput)` or `eval(userInput)` | Command/code injection | Never execute user input |
 | Query param used in file path | Path traversal | Validate and sanitize path |
+| `fetch(req.body.url)` or `requests.get(user_url)` | SSRF - internal network access | Allow-list permitted hosts; block private IP ranges |
+| `pickle.loads(data)`, `ObjectInputStream`, `yaml.load(input)` without `SafeLoader` | Insecure deserialization - remote code execution | Use safe formats (JSON) or safe loaders |
 
 ### ITSG-33 Controls
 - **SI-10:** Information Input Validation
@@ -87,7 +102,7 @@ Detailed patterns and guidance for ITSG-33 compliance review. This checklist is 
 ### What to Look For
 
 **Schema/Model Definitions:**
-- PII fields marked with metadata (`isPII`, `@Sensitive`, etc.)
+- PII fields marked with the project's metadata convention (`security.piiMetadataConvention` in `.gc-review/config.json`; e.g., `isPII`, `@Sensitive`)
 - Encryption-at-rest configuration for PII columns
 - Access controls on PII fields
 
@@ -106,59 +121,62 @@ Detailed patterns and guidance for ITSG-33 compliance review. This checklist is 
 | Pattern | Risk | Fix |
 |---------|------|-----|
 | `console.log(user)` or `logger.info(userData)` | PII in logs | Log only `userId` or masked data |
-| PII field without `isPII` metadata | Untracked sensitive data | Add `isPII: true` annotation |
+| PII field without project-convention metadata | Untracked sensitive data | Add the project's PII annotation (⚠️ Warning if no convention configured; ❌ Fail if `security.piiMetadataConvention` is set) |
 | Full user object in API response | Over-exposure of PII | Return only required fields |
 | SIN/birthdate in error message | PII leakage | Mask or omit PII in errors |
 
-### Privacy Act Requirements
-- Collection limitation
-- Purpose specification
-- Data minimization
-- Individual access rights
+### Privacy Act Context
+
+The *Privacy Act* (R.S.C. 1985, c. P-21) governs collection limitation, purpose specification, data minimization, and individual access rights (ss. 4–8, 12). It does **not** require code-level PII annotations — the metadata convention above is a project practice that supports those statutory obligations.
 
 ---
 
 ## D. Cryptography [SC Family]
 
-### Approved vs. Prohibited Algorithms
+### Approved vs. Prohibited Algorithms (ITSP.40.111 v5, effective 2026-05-29)
 
-| Purpose | Approved | Prohibited |
-|---------|----------|------------|
-| Hashing (passwords) | bcrypt, scrypt, Argon2 | MD5, SHA-1 |
-| Hashing (integrity) | SHA-256, SHA-384, SHA-512 | MD5, SHA-1 |
-| Symmetric encryption | AES-256 | DES, 3DES, RC4 |
-| Key exchange | ECDH, DH (2048+ bit) | RSA < 2048 bit |
+| Purpose | CCCS position | Prohibited / phase-out |
+|---------|---------------|------------------------|
+| Password storage (KDF) | CCCS-specified: PBKDF2 (NIST SP 800-132). Industry best practice (OWASP): Argon2id, bcrypt, scrypt — acceptable; flag as ⚠️ informational, not ❌ | MD5, SHA-1 |
+| Hashing (integrity/signatures) | SHA-2 family (SHA-256/384/512), SHA-3 family | MD5; **SHA-1 must not be used with digital signature schemes** |
+| Symmetric encryption | AES (128, 192, or 256-bit keys) | DES, 3DES, RC4 |
+| Key establishment | ECDH with curves P-256/P-384/P-521 (P-224 phase-out by 2030); RSA/DH ≥ 2048-bit now, ≥ 3072-bit by end of 2030 | RSA/DH < 2048-bit |
+| Post-quantum cryptography (PQC) | ML-KEM (512/768/1024) for key establishment; ML-DSA and SLH-DSA for signatures. Key-establishment implementations must support PQC by **end of 2026**; quantum-vulnerable RSA key establishment phased out by end of 2035 | New code introducing quantum-vulnerable-only key establishment → ⚠️ Warning |
 
 ### What to Look For
 
-**TLS Configuration:**
+**TLS Configuration (ITSP.40.062 v3):**
 - TLS 1.2 minimum, TLS 1.3 preferred
 - Strong cipher suites
 - Certificate validation enabled
 
-**Cookie Security:**
+**Cookie Security (OWASP best practice supporting ITSG-33 SC-23 Session Authenticity — not a GC configuration mandate):**
 - `HttpOnly` flag set
 - `Secure` flag set
-- `SameSite: Strict` or `SameSite: Lax`
+- A `SameSite` attribute present: `Strict` or `Lax` (flag `SameSite=None` as ⚠️ unless justified)
 
 **Secrets Management:**
 - No hardcoded credentials
 - Environment variables or secrets manager
-- No secrets in source control
+- No secrets in source control: no committed `.env` files, no keys in git history (`git log --diff-filter=A -- '*.env' '*.pem' '*.key'`)
 
 ### Common Patterns to Flag
 
 | Pattern | Risk | Fix |
 |---------|------|-----|
-| `md5(password)` or `sha1(password)` | Weak password hashing | Use bcrypt/Argon2 |
+| `md5(password)` or `sha1(password)` | Weak password hashing | Use PBKDF2 (CCCS-specified) or Argon2id/bcrypt/scrypt (OWASP) |
 | Cookie without `Secure` flag | Transmitted over HTTP | Add `Secure: true` |
+| Cookie without any `SameSite` attribute | CSRF exposure | Set `SameSite=Strict` or `SameSite=Lax` |
 | `const apiKey = "sk-..."` in code | Hardcoded secret | Use environment variable |
+| `.env` file committed or key files in git history | Leaked credentials persist in history | Remove, rotate secrets, purge history |
 | TLS 1.0/1.1 configuration | Weak encryption | Require TLS 1.2+ |
+| New RSA/ECDH key establishment with no PQC path | Quantum-vulnerable; misses ITSP.40.111 end-of-2026 PQC milestone | Plan ML-KEM support (hybrid acceptable) |
 
 ### ITSG-33 Controls
-- **SC-8:** Transmission Confidentiality
-- **SC-12:** Cryptographic Key Management
+- **SC-8:** Transmission Confidentiality and Integrity
+- **SC-12:** Cryptographic Key Establishment and Management
 - **SC-13:** Cryptographic Protection
+- **SC-23:** Session Authenticity
 - **SC-28:** Protection of Information at Rest
 
 ---
@@ -186,12 +204,17 @@ Detailed patterns and guidance for ITSG-33 compliance review. This checklist is 
 | Data Modification | Create, update, delete of sensitive records |
 | Admin Actions | User creation, role changes, config changes |
 
+### SIEM Forwarding (GC Event Logging Guidance, web configuration req. 4.3)
+
+Logs must reach an approved GC centralized SIEM. Direct console/stdout logging is **not** automatically a failure: stdout-to-SIEM pipelines are standard in containerized deployments. Flag as ⚠️ Warning and verify forwarding — unless `security.auditLogService` is configured and bypassed, which is ❌ Fail.
+
 ### Common Patterns to Flag
 
 | Pattern | Risk | Fix |
 |---------|------|-----|
 | Delete operation without audit log | Untraceable data changes | Add audit log call |
-| `console.log` for security events | Logs not collected by SIEM | Use centralized audit service |
+| `console.log` for security events with no SIEM-forwarded pipeline | Logs not collected by SIEM | Use centralized audit service, or confirm stdout forwarding to the SIEM (⚠️ pending verification) |
+| Security events bypassing the configured `security.auditLogService` | Sanctioned audit trail incomplete | Route events through the configured service (❌) |
 | Log missing user ID | Cannot attribute action | Include authenticated user ID |
 | Failed login not logged | Cannot detect brute force | Log all auth attempts |
 
@@ -200,3 +223,49 @@ Detailed patterns and guidance for ITSG-33 compliance review. This checklist is 
 - **AU-3:** Content of Audit Records
 - **AU-6:** Audit Review, Analysis, and Reporting
 - **AU-12:** Audit Generation
+
+---
+
+## F. Web Configuration & Security Headers [SC Family / GC Web Configuration Requirements]
+
+Source: GC *Web Sites and Services Management Configuration Requirements* (Date modified 2024-10-25). Requirement numbers below refer to that instrument.
+
+### What to Look For
+
+**Transport (reqs. 1.1–1.2, 1.4–1.6):**
+- HTTPS-only; HTTP requests redirect to HTTPS (req. 1.1)
+- HSTS enabled (req. 1.2)
+- TLS 1.2+ per ITSP.40.062 §3.1 and ITSP.40.111, other algorithms disabled (req. 1.4); SSL v2/v3 and TLS 1.0/1.1 disabled (req. 1.5); RC4 and 3DES disabled (req. 1.6)
+
+**Response Headers (req. 2.4 — mandated list):**
+- `Content-Security-Policy`
+- `Strict-Transport-Security` (HSTS)
+- `X-Frame-Options`
+- `X-Content-Type-Options: nosniff` — best-practice extra, not part of the mandated list (⚠️ if absent)
+
+**Application (reqs. 2.2–2.3, 2.5):**
+- Input validation/sanitization on all input (req. 2.2 — see section B)
+- Output encoding on all output (req. 2.3)
+- OWASP ASVS as the web application security verification baseline (req. 2.5)
+
+**CSRF Protection [SC family]:**
+- Anti-CSRF tokens or framework CSRF middleware on state-changing endpoints (cookie flags alone are insufficient)
+
+**Disclosure (req. 4.5):**
+- Published `security.txt` for public-facing sites
+
+### Common Patterns to Flag
+
+| Pattern | Risk | Fix |
+|---------|------|-----|
+| Server config listening on HTTP without redirect | Cleartext transmission | Redirect all HTTP to HTTPS (req. 1.1) |
+| No `Strict-Transport-Security` header in production config | Downgrade attacks | Enable HSTS (req. 1.2) |
+| Missing `Content-Security-Policy` or `X-Frame-Options` | XSS, clickjacking | Add mandated headers (req. 2.4) |
+| Template escaping disabled / `dangerouslySetInnerHTML` with unsanitized data | XSS via missing output encoding | Encode all output (req. 2.3) |
+| State-changing route without CSRF token/middleware | Cross-site request forgery | Add framework CSRF protection |
+| No `security.txt` in a public GC site repo | Vulnerability reporting channel missing | Publish `security.txt` (req. 4.5) — ⚠️ |
+
+### ITSG-33 Controls
+- **SC-8:** Transmission Confidentiality and Integrity
+- **SC-23:** Session Authenticity
+- **AU-2:** Audit Events (SIEM forwarding, req. 4.3 — see section E)

--- a/skills/gc-review-security/report-template.md
+++ b/skills/gc-review-security/report-template.md
@@ -9,7 +9,7 @@ Use this format when presenting security review findings.
 ```markdown
 ## Security Review Results
 
-**Policy Basis:** ITSG-33 (Security Controls); Directive on Service and Digital; Privacy Act
+**Policy Basis:** ITSG-33 (Security Controls); ITSP.40.111 v5; ITSP.40.062 v3; Directive on Service and Digital; Privacy Act
 **Scope:** [Files/components reviewed]
 **Date:** [Review date]
 
@@ -24,11 +24,11 @@ Use this format when presenting security review findings.
 
 | Status | File | Issue Found | Recommended Action |
 | :--- | :--- | :--- | :--- |
-| [Fail] | `path/to/file:line` | [AC] Missing RBAC check; endpoint accessible without authorization | Add role guard (e.g., `requireRole('ADMIN')`) at handler entry |
-| [Fail] | `path/to/file:line` | [PII] Logging entire user object containing PII | Log only `userId`; mask or omit PII fields |
-| [Warning] | `path/to/file:line` | [SI] Query parameter `id` not validated | Validate input format (e.g., UUID) before use |
-| [Warning] | `path/to/file:line` | [AU] Data modification without audit log | Add audit log call with required fields |
-| [Pass] | `path/to/file` | [SC] Encryption-at-rest correctly configured | None |
+| ❌ **Fail** | `path/to/file:line` | [AC] Missing RBAC check; endpoint accessible without authorization | Add role guard (e.g., `requireRole('ADMIN')`) at handler entry |
+| ❌ **Fail** | `path/to/file:line` | [PII] Logging entire user object containing PII | Log only `userId`; mask or omit PII fields |
+| ⚠️ **Warning** | `path/to/file:line` | [SI] Query parameter `id` not validated | Validate input format (e.g., UUID) before use |
+| ⚠️ **Warning** | `path/to/file:line` | [AU] Data modification without audit log | Add audit log call with required fields |
+| ✅ **Pass** | `path/to/file` | [SC] Encryption-at-rest correctly configured | None |
 
 ### Detailed Findings
 
@@ -39,6 +39,8 @@ Use this format when presenting security review findings.
 **Issue:** [Detailed description of the vulnerability]
 **Risk:** [What could happen if exploited]
 **Recommendation:** [Specific fix guidance]
+
+> **Disclaimer:** This is an automated pattern-based review and does not constitute a formal Security Assessment and Authorization (SA&A). Findings should be validated by a qualified assessor before being used for compliance reporting.
 ```
 
 ---
@@ -47,9 +49,18 @@ Use this format when presenting security review findings.
 
 | Status | Meaning | Action Required |
 |--------|---------|-----------------|
-| **[Fail]** | Security vulnerability or compliance violation | Must fix before deployment to production |
-| **[Warning]** | Potential risk or best practice deviation | Should address; review and remediate |
-| **[Pass]** | Compliant with security requirements | No action required |
+| ❌ **Fail** | Security vulnerability or compliance violation | Must fix before deployment to production |
+| ⚠️ **Warning** | Potential risk or best practice deviation | Should address; review and remediate |
+| ✅ **Pass** | Compliant with security requirements | No action required |
+
+**Inline flag mapping** (from the SKILL.md checklist — makes severity assignment deterministic):
+
+| Inline flag | Report status |
+|-------------|---------------|
+| `[Security Error: XX]` | ❌ **Fail** |
+| `[Security Warning: XX]` | ⚠️ **Warning** |
+
+If `security.strictMode` is enabled in `.gc-review/config.json`, ⚠️ **Warning** findings are reported as ❌ **Fail**.
 
 ---
 
@@ -60,11 +71,13 @@ When flagging issues, include the relevant ITSG-33 control family:
 | Code | Family | Typical Issues |
 |------|--------|----------------|
 | **AC** | Access Control | Missing auth, missing RBAC, IDOR |
-| **AU** | Audit and Accountability | Missing logs, incomplete log entries |
-| **IA** | Identification and Authentication | Weak auth, session issues |
-| **SC** | System and Communications Protection | Weak crypto, insecure transmission |
-| **SI** | System and Information Integrity | Input validation, injection |
+| **AU** | Audit and Accountability | Missing logs, incomplete log entries, no SIEM forwarding |
+| **SC** | System and Communications Protection | Weak crypto, insecure transmission, cookie flags, CSRF |
+| **SI** | System and Information Integrity | Input validation, injection, SSRF, insecure deserialization |
+| **WEB** | GC Web Configuration Requirements | Missing HTTPS/HSTS, mandated security headers, output encoding, security.txt |
 | **PII** | Privacy Act (not ITSG-33) | PII exposure, logging PII |
+
+> **Identification and Authentication (IA family):** IA checks (MFA, credential and authenticator management per IA-5, OIDC, session lifecycle) are covered by the sibling skill `gc-review-iam` and are not reported by this skill. Direct users there for authentication findings.
 
 ---
 
@@ -73,9 +86,9 @@ When flagging issues, include the relevant ITSG-33 control family:
 ```markdown
 ## Security Review Results
 
-**Policy Basis:** ITSG-33; Privacy Act
+**Policy Basis:** ITSG-33; ITSP.40.111 v5; Privacy Act
 **Scope:** `src/api/users.ts`, `src/handlers/admin.ts`
-**Date:** 2024-01-15
+**Date:** 2026-07-10
 
 ### Summary
 
@@ -88,13 +101,15 @@ When flagging issues, include the relevant ITSG-33 control family:
 
 | Status | File | Issue Found | Recommended Action |
 | :--- | :--- | :--- | :--- |
-| [Fail] | `src/handlers/admin.ts:45` | [AC] Admin endpoint missing role check | Add `requireRole('ADMIN')` guard |
-| [Fail] | `src/api/users.ts:112` | [PII] `logger.info(user)` logs full user object | Change to `logger.info({ userId: user.id, action: 'fetch' })` |
-| [Warning] | `src/api/users.ts:78` | [SI] `userId` param not validated | Add UUID validation before database query |
-| [Warning] | `src/handlers/admin.ts:89` | [AU] User deletion without audit log | Add `auditLog({ action: 'DELETE_USER', ... })` |
-| [Pass] | `src/config/cookies.ts` | [SC] Cookie security flags correctly set | None |
-| [Pass] | `src/models/User.ts` | [PII] PII fields properly annotated | None |
-| [Pass] | `src/db/queries.ts` | [SI] All queries use parameterization | None |
+| ❌ **Fail** | `src/handlers/admin.ts:45` | [AC] Admin endpoint missing role check | Add `requireRole('ADMIN')` guard |
+| ❌ **Fail** | `src/api/users.ts:112` | [PII] `logger.info(user)` logs full user object | Change to `logger.info({ userId: user.id, action: 'fetch' })` |
+| ⚠️ **Warning** | `src/api/users.ts:78` | [SI] `userId` param not validated | Add UUID validation before database query |
+| ⚠️ **Warning** | `src/handlers/admin.ts:89` | [AU] User deletion without audit log | Add `auditLog({ action: 'DELETE_USER', ... })` |
+| ✅ **Pass** | `src/config/cookies.ts` | [SC] Cookie security flags correctly set | None |
+| ✅ **Pass** | `src/models/User.ts` | [PII] PII fields properly annotated | None |
+| ✅ **Pass** | `src/db/queries.ts` | [SI] All queries use parameterization | None |
+
+> **Disclaimer:** This is an automated pattern-based review and does not constitute a formal Security Assessment and Authorization (SA&A). Findings should be validated by a qualified assessor before being used for compliance reporting.
 ```
 
 ---


### PR DESCRIPTION
Implements all eight recommendations (R1–R8) from the gc-review-security efficacy audit. Audit source: `.gc-review/efficacy-audit/gc-review-security.md` (local audit artifact, not committed), including its 2026-07-10 post-audit updates on the GC web configuration requirements.

## Changes by recommendation

| R# | Change |
|----|--------|
| R1 | Corrected Standards Reference block in SKILL.md: ITSG-33 effective 2012-11-01 with Annex 3A (December 2014, NIST SP 800-53 rev. 4); added ITSP.40.111 v5 (effective 2026-05-29) and ITSP.40.062 v3 (January 2025); Directive on Service and Digital with 2025-08-29 amendments; Privacy Act last amended 2025-06-02. EN/FR instrument titles; **Last Verified: 2026-07-10**. |
| R2 | Rebuilt the checklist.md crypto table on ITSP.40.111 v5: AES-128/192/256 approved; PBKDF2 as the CCCS-specified KDF with Argon2id/bcrypt/scrypt labeled OWASP industry practice (informational, not Fail); ECDH P-256/P-384/P-521 (P-224 phase-out by 2030); RSA/DH >= 2048 now, >= 3072 by end of 2030; new PQC row (ML-KEM/ML-DSA/SLH-DSA, end-of-2026 key-establishment milestone, RSA key-establishment phase-out by 2035); SHA-1 prohibition noted specifically for digital signatures. |
| R3 | SameSite fix: rule now requires a `SameSite` attribute (`Strict` or `Lax`), with `SameSite=None` a warning unless justified — matching checklist.md. Cookie-flag rules re-attributed to OWASP/industry best practice supporting ITSG-33 SC-23, not a GC mandate (verified: the GC web configuration requirements page contains no cookie clauses). |
| R4 | report-template.md now uses literal ❌ **Fail** / ⚠️ **Warning** / ✅ **Pass** throughout (findings tables, status definitions, example report); added `[Security Warning: XX]` inline flag tier and a deterministic flag-to-status mapping table. |
| R5 | Added `Bash` to allowed-tools; new step 1 detects changed files via `git diff --name-only main...HEAD` with fallback to user-provided scope. |
| R6 | Added `.gc-review/config.json` support (options under the `"security"` namespace: `piiMetadataConvention`, `auditLogService`, `approvedAlgorithmExceptions`, `strictMode`) with a new `skills/gc-review-security/CONFIG.md`; rule C reworded so PII metadata is a project convention supporting Privacy Act obligations, not an Act requirement (missing metadata downgrades to Warning when no convention is configured). |
| R7 | Coverage: new section F for HTTPS-only + redirect (req. 1.1), HSTS (1.2), mandated headers Content-Security-Policy + HSTS + X-Frame-Options (2.4; X-Content-Type-Options as best-practice extra), output encoding (2.3), OWASP ASVS baseline (2.5), security.txt (4.5); SIEM-forwarded logging per GC Event Logging Guidance (4.3) with the console-logging fail softened to a warning unless a sanctioned audit service is configured and bypassed; added SSRF, insecure deserialization, CSRF, and secrets-in-repo (.env / keys in history) checks. IA family: removed the IA row from report-template.md and added explicit cross-references to `gc-review-iam` — no duplicated IA checks. |
| R8 | Control-name fixes: SC-8 "Transmission Confidentiality and Integrity", SC-12 "Cryptographic Key Establishment and Management"; description frontmatter normalized to an unquoted capability sentence matching sibling skills. |

Also: surgical README updates — the `gc-review-security` description subsection (EN + FR) and a new `gc-review-security` configuration subsection.

**Deferred:** none — all of R1–R8 implemented.

Policy citations verified 2026-07-10.

> Note: this is an automated skill-definition update, not a formal compliance assessment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)