### PR TITLE
gc-review-branding: implement efficacy-audit recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ Vérifie les implémentations d'authentification selon les normes d'identité du
 </div>
 
 ### `gc-review-branding`
-Reviews code for Federal Identity Program compliance. Verifies GC signatures, Canada wordmark usage, typography, color tokens, and mandatory footer elements per the Policy on Communications and Federal Identity.
+Reviews code for Federal Identity Program compliance. Verifies GC signatures, Canada wordmark usage, typography, color tokens, and mandatory header/footer elements per the Policy on Communications and Federal Identity, and recognizes official GC Design System (GCDS) components as compliant.
 
 <div lang="fr">
 
-Vérifie la conformité du code au Programme de coordination de l'image de marque. Contrôle les signatures du GC, l'utilisation du mot-symbole « Canada », la typographie, les jetons de couleur et les éléments obligatoires du pied de page selon la Politique sur les communications et l'image de marque.
+Vérifie la conformité du code au Programme de coordination de l'image de marque. Contrôle les signatures du GC, l'utilisation du mot-symbole « Canada », la typographie, les jetons de couleur et les éléments obligatoires de l'en-tête et du pied de page selon la Politique sur les communications et l'image de marque, et reconnaît les composants officiels du Système de design GC (GCDS) comme conformes.
 
 </div>
 
@@ -171,14 +171,31 @@ See [`skills/gc-review-im/CONFIG.md`](skills/gc-review-im/CONFIG.md) for the ful
 
 #### `gc-review-branding`
 
+All options live under the `"branding"` key. / <span lang="fr">Toutes les options se trouvent sous la clé `"branding"`.</span>
+
 | Field | Type | Description |
 |-------|------|-------------|
-| `department` | `string` | Department name for reporting |
-| `signature.altText` | `string` | Expected alt text for GC signature |
-| `signature.componentName` | `string` | Custom component name for GC signature |
-| `wordmark.componentName` | `string` | Custom component name for Canada wordmark |
-| `additionalColors` | `object` | Extra approved color tokens (map of token name to hex value) |
-| `excludePatterns` | `string[]` | File patterns to skip |
+| `branding.department` | `string` | Department name for reporting |
+| `branding.signature.altText` | `string` | Expected alt text for GC signature |
+| `branding.signature.componentName` | `string` | Custom component name for GC signature |
+| `branding.wordmark.componentName` | `string` | Custom component name for Canada wordmark |
+| `branding.additionalColors` | `object` | Extra approved color tokens (map of token name to hex value) |
+| `branding.additionalFonts` | `string[]` | Extra approved font families / <span lang="fr">Familles de polices supplémentaires approuvées</span> |
+| `branding.exclude` | `string[]` | Glob patterns for files to skip |
+| `branding.strictMode` | `boolean` | Treat warnings as failures / <span lang="fr">Traiter les avertissements comme des échecs</span> |
+
+```json
+{
+  "version": 1,
+  "branding": {
+    "department": "Parks Canada",
+    "additionalFonts": ["Montserrat"],
+    "strictMode": false
+  }
+}
+```
+
+See [`skills/gc-review-branding/CONFIG.md`](skills/gc-review-branding/CONFIG.md) for the full schema.
 
 ---
 

--- a/skills/gc-review-branding/CONFIG.md
+++ b/skills/gc-review-branding/CONFIG.md
@@ -4,32 +4,34 @@ This document describes the configuration options for the `gc-review-branding` s
 
 ## Configuration File
 
-Create `.gc-review/config.json` in your project root to customize the review behavior.
+Create `.gc-review/config.json` in your project root to customize the review behavior. All branding options live under the `"branding"` namespace, alongside other skills' namespaces in the same shared file.
 
 ## Full Schema
 
 ```json
 {
   "version": 1,
-  "department": "Department of Example",
-  "signature": {
-    "altText": "Government of Canada / Gouvernement du Canada",
-    "componentName": "GCSignature"
-  },
-  "wordmark": {
-    "componentName": "CanadaWordmark"
-  },
-  "additionalColors": {
-    "--dept-accent": "#custom-hex",
-    "--dept-secondary": "#another-hex"
-  },
-  "additionalFonts": ["Montserrat"],
-  "excludePatterns": [
-    "vendor/*",
-    "*.generated.*",
-    "node_modules/**"
-  ],
-  "strictMode": false
+  "branding": {
+    "department": "Department of Example",
+    "signature": {
+      "altText": "Government of Canada / Gouvernement du Canada",
+      "componentName": "GCSignature"
+    },
+    "wordmark": {
+      "componentName": "CanadaWordmark"
+    },
+    "additionalColors": {
+      "--dept-accent": "#custom-hex",
+      "--dept-secondary": "#another-hex"
+    },
+    "additionalFonts": ["Montserrat"],
+    "exclude": [
+      "vendor/*",
+      "*.generated.*",
+      "node_modules/**"
+    ],
+    "strictMode": false
+  }
 }
 ```
 
@@ -37,15 +39,15 @@ Create `.gc-review/config.json` in your project root to customize the review beh
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `version` | number | `1` | Config schema version |
-| `department` | string | — | Department name for reporting |
-| `signature.altText` | string | `"Government of Canada"` | Expected alt text for GC signature |
-| `signature.componentName` | string | `"GCSignature"` | Component name to search for |
-| `wordmark.componentName` | string | `"CanadaWordmark"` | Wordmark component name |
-| `additionalColors` | object | `{}` | Extra approved color tokens |
-| `additionalFonts` | array | `[]` | Extra approved font families |
-| `excludePatterns` | array | `[]` | Glob patterns to skip |
-| `strictMode` | boolean | `false` | Treat warnings as failures |
+| `version` | number | `1` | Config schema version (top-level, required) |
+| `branding.department` | string | — | Department name for reporting |
+| `branding.signature.altText` | string | `"Government of Canada"` | Expected alt text for GC signature |
+| `branding.signature.componentName` | string | `"GCSignature"` | Component name to search for |
+| `branding.wordmark.componentName` | string | `"CanadaWordmark"` | Wordmark component name |
+| `branding.additionalColors` | object | `{}` | Extra approved color tokens (Step 7) |
+| `branding.additionalFonts` | array | `[]` | Extra approved font families (Step 6) |
+| `branding.exclude` | array | `[]` | Glob patterns to skip (Step 3) |
+| `branding.strictMode` | boolean | `false` | Treat warnings as failures (Step 10) |
 
 ## Examples
 
@@ -54,7 +56,9 @@ Create `.gc-review/config.json` in your project root to customize the review beh
 ```json
 {
   "version": 1,
-  "department": "Employment and Social Development Canada"
+  "branding": {
+    "department": "Employment and Social Development Canada"
+  }
 }
 ```
 
@@ -65,11 +69,13 @@ If your project uses non-standard component names:
 ```json
 {
   "version": 1,
-  "signature": {
-    "componentName": "GovHeader"
-  },
-  "wordmark": {
-    "componentName": "FederalWordmark"
+  "branding": {
+    "signature": {
+      "componentName": "GovHeader"
+    },
+    "wordmark": {
+      "componentName": "FederalWordmark"
+    }
   }
 }
 ```
@@ -81,25 +87,44 @@ If your department has approved accent colors:
 ```json
 {
   "version": 1,
-  "department": "Parks Canada",
-  "additionalColors": {
-    "--parks-green": "#2E8B57",
-    "--parks-brown": "#8B4513"
+  "branding": {
+    "department": "Parks Canada",
+    "additionalColors": {
+      "--parks-green": "#2E8B57",
+      "--parks-brown": "#8B4513"
+    }
   }
 }
 ```
+
+### Additional Approved Fonts
+
+If your application has an approved exception to the Lato / Noto Sans stack:
+
+```json
+{
+  "version": 1,
+  "branding": {
+    "additionalFonts": ["Montserrat", "Source Sans Pro"]
+  }
+}
+```
+
+Fonts listed here are treated as approved during the Step 6 typography audit.
 
 ### Excluding Generated Files
 
 ```json
 {
   "version": 1,
-  "excludePatterns": [
-    "*.generated.tsx",
-    "dist/**",
-    "coverage/**",
-    "__mocks__/**"
-  ]
+  "branding": {
+    "exclude": [
+      "*.generated.tsx",
+      "dist/**",
+      "coverage/**",
+      "__mocks__/**"
+    ]
+  }
 }
 ```
 
@@ -110,18 +135,20 @@ Enable strict mode to fail builds on any compliance issue:
 ```json
 {
   "version": 1,
-  "strictMode": true
+  "branding": {
+    "strictMode": true
+  }
 }
 ```
 
-In strict mode, warnings are elevated to failures, causing the review to report an overall FAIL status.
+In strict mode, the Step 10 report elevates warnings to failures, causing the review to report an overall FAIL status when any finding exists.
 
 ## Validation
 
 The skill validates your config on load:
 
 1. **JSON syntax** - Must be valid JSON
-2. **Version check** - Must be version `1`
+2. **Version check** - Must contain `"version": 1` (required); configs without it are rejected
 3. **Type validation** - Each field must match expected type
 4. **Pattern validation** - Exclude patterns must be valid globs
 
@@ -134,4 +161,4 @@ The config file must be at:
 .gc-review/config.json
 ```
 
-This keeps branding configuration separate from other project configs and allows easy exclusion from version control if needed.
+This keeps GC review configuration separate from other project configs and allows easy exclusion from version control if needed.

--- a/skills/gc-review-branding/SKILL.md
+++ b/skills/gc-review-branding/SKILL.md
@@ -1,14 +1,23 @@
 ---
 name: gc-review-branding
-description: Review code for Government of Canada branding compliance - verifies Federal Identity Program symbols, typography, design tokens, and GC Design System patterns
+description: Review code for Government of Canada branding compliance - verifies Federal Identity Program symbols, typography, design tokens, and Canada.ca / GC Design System (GCDS) patterns
 allowed-tools: Read, Grep, Glob, Bash
 ---
 
 # GC Branding & Design Reviewer
 
-You are a Government of Canada Branding and Federal Identity Program (FIP) Specialist. Your role is to analyze code changes for compliance with the *Policy on Communications and Federal Identity* (effective 2025-03-27), the *Directive on the Management of Communications and Federal Identity* (effective 2025-03-27), the *Design Standard for the Federal Identity Program*, and the *GC Design System*.
+You are a Government of Canada Branding and Federal Identity Program (FIP) Specialist. Your role is to analyze code changes for compliance with:
 
-**Last Verified:** 2026-03-11
+- the *Policy on Communications and Federal Identity* / <span lang="fr">*Politique sur les communications et l'image de marque*</span> (effective 2025-03-27, replacing the 2016-05-11 instrument; issued under s. 7 of the *Financial Administration Act* / <span lang="fr">*Loi sur la gestion des finances publiques*</span>, R.S.C. 1985, c. F-11)
+- the *Directive on the Management of Communications and Federal Identity* / <span lang="fr">*Directive sur la gestion des communications et de l'image de marque*</span> (effective 2025-03-27; requirement 4.1.13 takes effect 2026-03-27)
+- the *Design Standard for the Federal Identity Program* / <span lang="fr">*Norme graphique du Programme de coordination de l'image de marque*</span>
+- the Canada.ca design system (specifications at [design.canada.ca](https://design.canada.ca/)) and the GC Design System (GCDS, component and token library at [design-system.canada.ca](https://design-system.canada.ca/))
+
+**Last Verified:** 2026-07-10
+
+**Note on detection patterns:** All detection patterns in this skill are indicative, not literal regex — read the surrounding code for context before reporting a finding.
+
+**Note on GCDS:** Projects built on the official GC Design System component library (imports from `@cdssnc/gcds-components`, or `<gcds-*>` custom elements such as `<gcds-signature>`, `<gcds-header>`, `<gcds-footer>`) implement the corresponding mandatory elements correctly by construction. Treat these components as automatically compliant — do not raise custom-component, font, or colour findings against them.
 
 ## Workflow
 
@@ -24,7 +33,8 @@ cat .gc-review/config.json 2>/dev/null
 ```
 
 **2. If config exists, validate and load:**
-- Parse JSON and extract department-specific overrides
+- Parse JSON. The config must contain `"version": 1` — reject configs without it (produce a warning and fall back to defaults)
+- Read branding options from the `"branding"` namespace
 - Store configuration for use in subsequent checks
 - Output: `Loaded GC branding config for: [department name]`
 
@@ -32,13 +42,17 @@ cat .gc-review/config.json 2>/dev/null
 - Use default FIP standards (silent, no output)
 - Proceed with standard checks
 
-**Configuration fields (all optional):**
-- `department`: Department name for reporting
-- `signature.altText`: Expected alt text for GC signature
-- `signature.componentName`: Custom component name to search for
-- `wordmark.componentName`: Custom wordmark component name
-- `additionalColors`: Extra approved color tokens
-- `excludePatterns`: File patterns to skip
+**Configuration fields (all optional, all under the `"branding"` key):**
+- `branding.department`: Department name for reporting
+- `branding.signature.altText`: Expected alt text for GC signature
+- `branding.signature.componentName`: Custom component name to search for
+- `branding.wordmark.componentName`: Custom wordmark component name
+- `branding.additionalColors`: Extra approved color tokens (used in Step 7)
+- `branding.additionalFonts`: Extra approved font families (used in Step 6)
+- `branding.exclude`: File glob patterns to skip (used in Step 3)
+- `branding.strictMode`: When `true`, warnings are elevated to failures in the Step 10 report
+
+See [CONFIG.md](CONFIG.md) for the full schema.
 
 ### Step 2: Detect Changes
 
@@ -91,7 +105,7 @@ git diff --name-only [source]
 
 **2. Filter for relevant files:**
 - Match against target patterns
-- Exclude patterns from config (if loaded)
+- Exclude glob patterns from config (`branding.exclude`, if loaded)
 - If no relevant files found, output: "No branding-relevant files in this diff. Skipping review." and end.
 
 **3. Read full content of relevant files:**
@@ -104,19 +118,24 @@ Verify the Federal Identity Program symbols are correctly implemented.
 
 **A. Government of Canada Signature (Header)**
 
-The GC Signature must appear in the global header, top-left position, and must link to the Canada.ca home page.
+The GC Signature must appear in the global header, top-left position, and must link to the Canada.ca home page (on transactional pages, the home link is optional — see below).
 
 **What to look for:**
 - Image/component with "Government of Canada" or "Gouvernement du Canada"
 - SVG or image asset containing the flag symbol
 - Component names: `GCSignature`, `GovCanSignature`, `CanadaSignature`, or config override
+- GCDS components: `<gcds-signature>`, or `<gcds-header>` (which renders the signature) — automatically compliant
 - Alt text containing "Government of Canada"
 - Wrapped in a link to `canada.ca/en` or `canada.ca/fr` (the Canada.ca home page)
 
-**Check patterns:**
+**Check patterns (indicative, not literal regex — read the surrounding code for context):**
 ```
 # React/Vue/Svelte components
 <GCSignature, <GovCanSignature, <CanadaSignature
+
+# GC Design System (automatically compliant)
+<gcds-signature, <gcds-header
+import ... from "@cdssnc/gcds-components"
 
 # Image references
 gc-signature, gov-canada-sig, fip-signature
@@ -133,8 +152,8 @@ href="https://canada.ca"
 
 **Violations:**
 - ❌ **Fail**: Signature completely missing from header
-- ❌ **Fail**: Signature not in header/top-left position
-- ❌ **Fail**: Signature not linked to Canada.ca home page
+- ❌ **Fail**: Signature not linked to Canada.ca home page (standard and campaign pages only — on **transactional pages** the signature's link to the Canada.ca home page is **optional** per the global header spec, mirroring the language-toggle data-loss exemption)
+- ⚠️ **Warning**: Signature top-left position could not be confirmed from code — verify visually (position is a visual-design spec, not reliably code-detectable)
 - ⚠️ **Warning**: Signature present but missing bilingual alt text
 
 **B. Canada Wordmark (Footer)**
@@ -145,35 +164,44 @@ The Canada Wordmark must appear in the global footer, bottom-right position.
 - Image/component showing "Canada" with flag diacritical
 - SVG or image asset for the wordmark
 - Component names: `CanadaWordmark`, `GCWordmark`, `FIPWordmark`, or config override
+- GCDS component: `<gcds-footer>` (renders the wordmark) — automatically compliant
 - Positioned in footer, aligned right
 
-**Check patterns:**
+**Check patterns (indicative, not literal regex — read the surrounding code for context):**
 ```
 # React/Vue/Svelte components
 <CanadaWordmark, <GCWordmark, <FIPWordmark
 
+# GC Design System (automatically compliant)
+<gcds-footer
+
 # Image references
 canada-wordmark, gc-wordmark, fip-wordmark
 
-# CSS positioning
+# CSS positioning (heuristics only — do not fail on these)
 footer.*right, justify-end, ml-auto, float-right
 ```
 
 **Violations:**
 - ❌ **Fail**: Wordmark completely missing from footer
-- ❌ **Fail**: Wordmark not in footer/bottom-right position
-- ⚠️ **Warning**: Wordmark present but unclear positioning
+- ⚠️ **Warning**: Wordmark bottom-right position could not be confirmed from code — verify visually (valid flex/grid layouts may not match the CSS heuristics above)
 
 **C. Symbol Colors**
 
-FIP symbols must use standard colors.
+FIP symbols must use standard colors, per Table 1 of the *Design Standard for the Federal Identity Program* colour page (page dated 2021-12-13).
 
-**Official FIP Colors:**
-| Name | Hex | CSS Variable |
-|------|-----|--------------|
-| FIP Red | `#A62A1E` | `--gc-color-red` |
-| Black | `#000000` | `--gc-color-black` |
-| White | `#FFFFFF` | `--gc-color-white` |
+**Official FIP Colours:**
+
+| Name | Pantone / Process | CMYK | RGB | Approx. Hex | Used For |
+|------|-------------------|------|-----|-------------|----------|
+| FIP red | Pantone 032 | 0, 100, 100, 0 | 235, 45, 55 | `#EB2D37` | Flag symbol in the Canada wordmark, corporate signatures, and ministerial signatures |
+| Black | Process black | — | 0, 0, 0 | `#000000` | Signature/wordmark text and standard applications |
+| White | Process white | — | 255, 255, 255 | `#FFFFFF` | Reversed applications |
+| Pewter grey | Pantone 429 | — | 150, 150, 150 | `#969696` | Ministerial signatures |
+
+**Important:**
+- `#FF0000` is a common secondary-source figure but is **not** the official FIP red RGB value.
+- `#A62A1E` is the Canada.ca **H1 red bar / accent** colour (see Steps 6–8), **not** the FIP symbol colour. Do not require it for signatures or the wordmark, and do not flag signatures that correctly use FIP red (RGB 235, 45, 55).
 
 **Violations:**
 - ⚠️ **Warning**: Symbol using non-standard color values
@@ -187,10 +215,13 @@ Verify the bilingual language toggle is correctly implemented.
 - Must switch between English and French
 - Standard format: "English" / "Français" or "EN" / "FR"
 
-**What to look for:**
+**What to look for (indicative, not literal regex — read the surrounding code for context):**
 ```
 # Component patterns
 <LanguageToggle, <LangToggle, <LanguageSwitcher
+
+# GC Design System (automatically compliant)
+<gcds-lang-toggle, <gcds-header
 
 # Link patterns
 href="*/en/", href="*/fr/"
@@ -215,13 +246,13 @@ Verify the remaining mandatory header elements for standard pages.
 
 | Element | Requirement | What to Look For |
 |---------|-------------|------------------|
-| Site Search Box | Must appear in header | `<input type="search">`, `role="search"`, search form component |
-| Theme and Topic Menu | Mandatory (removable if analytics show <1% usage) | Navigation menu, `<nav>`, menu toggle button |
-| Breadcrumb Trail | Must appear below header divider | `<nav aria-label="breadcrumb">`, breadcrumb component, "Canada.ca" as first item |
+| Site Search Box | Must appear in header | `<input type="search">`, `role="search"`, search form component, `<gcds-search>` |
+| Theme and Topic Menu | Mandatory (removable if analytics show <1% usage) | Navigation menu, `<nav>`, menu toggle button, `<gcds-top-nav>` |
+| Breadcrumb Trail | Must appear below header divider | `<nav aria-label="breadcrumb">`, breadcrumb component, `<gcds-breadcrumbs>`, "Canada.ca" as first item |
 | Divider Line | Separates header sections | `<hr>`, border-bottom styles on header rows |
 | White Background | Header must use white background | Background color on header container |
 
-**Check patterns:**
+**Check patterns (indicative, not literal regex — read the surrounding code for context):**
 ```
 # Search box
 <input type="search", role="search", <SearchBox, <SiteSearch
@@ -232,6 +263,9 @@ aria-label="breadcrumb", <Breadcrumb, <GCBreadcrumb
 
 # Menu
 <GCMenu, <ThemeMenu, <TopicMenu
+
+# GC Design System (automatically compliant)
+<gcds-search, <gcds-breadcrumbs, <gcds-top-nav, <gcds-header
 ```
 
 **Violations:**
@@ -244,7 +278,7 @@ aria-label="breadcrumb", <Breadcrumb, <GCBreadcrumb
 
 Scan stylesheets and theme files for font declarations.
 
-**Approved Fonts (GC Design System):**
+**Approved Fonts (Canada.ca design system):**
 
 | Context | Font Family | Weight | Notes |
 |---------|-------------|--------|-------|
@@ -252,6 +286,8 @@ Scan stylesheets and theme files for font declarations.
 | Body text | `Noto Sans` | Regular | Primary body font |
 | Indigenous languages | `Noto Sans Canadian Aboriginal` | Regular | Included by default |
 | Fallback | `Helvetica`, `Arial`, `sans-serif` | — | Generic fallback stack |
+
+Fonts listed in `branding.additionalFonts` (config) are also approved — do not flag them.
 
 **Expected Heading Sizes:**
 
@@ -267,7 +303,7 @@ Scan stylesheets and theme files for font declarations.
 
 **Line Length:** Constrain text line length to 65 characters maximum for readability.
 
-**What to scan:**
+**What to scan (indicative, not literal regex — read the surrounding code for context):**
 ```css
 font-family: ...
 --font-family: ...
@@ -278,7 +314,7 @@ max-width: ...ch
 **Violations:**
 - ⚠️ **Warning**: Heading font is not Lato (H1–H6 must use Lato bold)
 - ⚠️ **Warning**: Body font is not Noto Sans
-- ⚠️ **Warning**: Non-approved font in font stack (e.g., Roboto, Open Sans, custom fonts)
+- ⚠️ **Warning**: Non-approved font in font stack (e.g., Roboto, Open Sans, custom fonts) — do **not** flag fonts listed in `branding.additionalFonts` or GCDS `--gcds-*` font tokens
 - ⚠️ **Warning**: Heading/body font sizes significantly deviate from GC spec
 - ⚠️ **Warning**: Text line length not constrained to ~65 characters
 
@@ -288,27 +324,31 @@ max-width: ...ch
 font-family: "Lato", Helvetica, Arial, sans-serif;
 /* Body */
 font-family: "Noto Sans", Helvetica, Arial, sans-serif;
-/* CSS variable usage */
-font-family: var(--gc-font-family);
-font-family: var(--gc-heading-font-family);
+/* GC Design System (GCDS) design tokens — any --gcds-* font token is compliant */
+font-family: var(--gcds-font-families-heading);
+font-family: var(--gcds-font-families-body);
 ```
 
 ### Step 7: Color Token Audit
 
 Scan for non-compliant color values.
 
-**GC Design System Colors:**
-| Purpose | Hex | CSS Variable |
-|---------|-----|--------------|
-| Link Default | `#284162` | `--gc-color-link` |
-| Link Hover/Focus | `#0535d2` | `--gc-color-link-hover` |
-| Link Visited | `#7834bc` | `--gc-color-link-visited` |
-| FIP Red / Accent | `#A62A1E` | `--gc-color-red` |
-| Text | `#333333` | `--gc-color-text` |
-| Background | `#FFFFFF` | `--gc-color-bg` |
-| Form Error | `#d3080c` | `--gc-color-error` |
-| Accent | `#26374A` | `--gc-color-accent` |
-| Muted | `#6c757d` | `--gc-color-muted` |
+**Canada.ca Colours** (per https://design.canada.ca/styles/colours.html):
+
+| Purpose | Hex |
+|---------|-----|
+| Link Default | `#284162` |
+| Link Hover/Focus | `#0535d2` |
+| Link Visited | `#7834bc` |
+| H1 Red Bar / Accent | `#A62A1E` |
+| Text | `#333333` |
+| Background | `#FFFFFF` |
+| Form Error | `#d3080c` |
+| Accent | `#26374A` |
+
+**Token guidance:** recommend either the plain hex values above or the corresponding `--gcds-*` design token from the GC Design System ([design tokens](https://design-system.canada.ca/en/styles/design-tokens/), [`@cdssnc/gcds-tokens`](https://github.com/cds-snc/gcds-tokens)). Do **not** recommend CSS variables with a bare `--gc-` prefix — no GC design system publishes such tokens (GCDS tokens use `--gcds-`).
+
+**Note on `#6c757d`:** this "muted" grey is Bootstrap's secondary text colour, **not** part of the Canada.ca colour specification. Treat it as a non-GC convenience value — approved only if listed in `branding.additionalColors`.
 
 **What to scan:**
 - Direct hex values in CSS/SCSS
@@ -317,17 +357,16 @@ Scan for non-compliant color values.
 - Tailwind config custom colors
 
 **Violations:**
-- ⚠️ **Warning**: Link color not using `#284162` or `--gc-color-link`
-- ⚠️ **Warning**: Custom color values not in approved palette
-- ⚠️ **Warning**: Hardcoded hex instead of CSS variable/token
-
-**Note:** Colors defined in `additionalColors` config are considered approved.
+- ⚠️ **Warning**: Link color not using `#284162` (or the corresponding `--gcds-*` token)
+- ⚠️ **Warning**: Custom color values not in the approved palette (colors defined in `branding.additionalColors` are considered approved)
 
 ### Step 8: Component Consistency Check
 
-Flag custom implementations of standard GC Design System components.
+Flag custom implementations of standard Canada.ca / GC Design System components.
 
-**GC Design System Components:**
+**GCDS components are automatically compliant:** `<gcds-button>`, `<gcds-date-modified>`, `<gcds-breadcrumbs>`, and other `<gcds-*>` components from `@cdssnc/gcds-components` implement the official patterns — do not flag them as custom.
+
+**Standard components to check:**
 
 | Component | Description | Patterns to Detect Custom |
 |-----------|-------------|---------------------------|
@@ -338,10 +377,10 @@ Flag custom implementations of standard GC Design System components.
 | Date Modified | Last update date | Custom date display, wrong format |
 | Pagination | Page navigation | Custom pagination component |
 
-**What to look for:**
+**What to look for (indicative, not literal regex — read the surrounding code for context):**
 ```
 # H1 Red Bar Accent
-# Must be: #A62A1E, 72px wide, 6px thick, positioned 0.2em below H1
+# Must be: #A62A1E, 72px wide, 6px thick, positioned 7.6px below the H1
 border-bottom, ::after, ::before on h1
 background-color or border-color matching #A62A1E
 
@@ -352,17 +391,19 @@ role="alert" without gc-alert class
 # Custom Button detection
 <button class="btn-custom, <Button variant="custom"
 Non-standard button colors/styles
+(<gcds-button> is compliant)
 
 # Date Modified detection
 "Last updated:", "Modified:", "Date:"
 Format not YYYY-MM-DD
+(<gcds-date-modified> is compliant)
 ```
 
 **Violations:**
-- ⚠️ **Warning**: H1 red bar accent missing (should be `#A62A1E`, 72px wide, 6px thick, 0.2em below H1)
+- ⚠️ **Warning**: H1 red bar accent missing (should be `#A62A1E`, 72px wide, 6px thick, 7.6px below the H1)
 - ⚠️ **Warning**: H1 red bar accent using wrong color or dimensions
 - ⚠️ **Warning**: Custom Alert component (should use GC Alert pattern)
-- ⚠️ **Warning**: Custom Button styling (should use GC Button)
+- ⚠️ **Warning**: Custom Button styling (should use GC Button or `<gcds-button>`)
 - ⚠️ **Warning**: Date Modified using wrong format (must be YYYY-MM-DD)
 - ⚠️ **Warning**: Date Modified missing from content pages
 
@@ -378,15 +419,20 @@ Format not YYYY-MM-DD
 
 The GC global footer has a 3-band structure. Verify the correct bands and links are present.
 
+**GCDS note:** `<gcds-footer>` renders the compliant footer bands, links, and wordmark automatically — treat it as passing this entire step.
+
 **A. Sub-footer Band (Mandatory on ALL page types)**
 
-This band must always be present, even on transactional and campaign pages.
+This band must always be present. On transactional and campaign pages the minimum link set is Terms and conditions + Privacy; on standard pages the full link set is mandatory.
 
-| Element | Purpose | URL Pattern |
-|---------|---------|-------------|
-| Terms and Conditions | Terms of use | `/terms`, `/conditions` |
-| Privacy | Privacy notice | `/privacy`, `/confidentialite` |
-| Canada Wordmark | FIP identity (checked in Step 4B) | Bottom-right position |
+| Element | Mandatory On | Purpose / URL Pattern |
+|---------|--------------|-----------------------|
+| Social media / <span lang="fr">Médias sociaux</span> | Standard pages | GC social media directory — `/social` |
+| Mobile applications / <span lang="fr">Applications mobiles</span> | Standard pages | GC mobile apps directory — `/mobile` |
+| About Canada.ca / <span lang="fr">À propos de Canada.ca</span> | Standard pages | About the site — `/about`, `/apropos` |
+| Terms and conditions / <span lang="fr">Avis</span> | All page types | Terms of use — `/terms`, `/conditions`, `/avis` |
+| Privacy / <span lang="fr">Confidentialité</span> | All page types | Privacy notice — `/privacy`, `/confidentialite` |
+| Canada Wordmark | All page types | FIP identity (checked in Step 4B), bottom-right position |
 
 **B. Main Footer Band (Mandatory on standard pages)**
 
@@ -396,31 +442,44 @@ This band must always be present, even on transactional and campaign pages.
 | Departments and agencies | GC org directory | `/government/dept`, `/gouvernement/min` |
 | About government | GC system info | `/government/system`, `/gouvernement/systeme` |
 
+The main band also carries the Canada.ca theme and topic links on standard Canada.ca pages.
+
 **C. Contextual Band (Optional)**
 
 Department-specific links. No mandatory requirements.
 
-**What to look for:**
+**What to look for (indicative, not literal regex — read the surrounding code for context):**
 ```
-# Sub-footer links (mandatory on ALL pages)
+# Sub-footer links (minimum set, mandatory on ALL pages)
 href="*/privacy*", href="*/confidentialite*"
 href="*/terms*", href="*/conditions*"
 "Privacy", "Confidentialité"
 "Terms and conditions", "Avis"
 
+# Sub-footer links (full set, mandatory on standard pages)
+"Social media", "Médias sociaux"
+"Mobile applications", "Applications mobiles"
+"About Canada.ca", "À propos de Canada.ca"
+
 # Main band links (mandatory on standard pages)
 href="*/contact*"
 href="*/government/dept*", href="*/gouvernement/min*"
 href="*/government/system*", href="*/gouvernement/systeme*"
-"All contacts", "Tous les coordonnées"
+"All contacts", "Toutes les coordonnées"
 "Departments and agencies", "Ministères et organismes"
 "About government", "À propos du gouvernement"
+
+# GC Design System (automatically compliant)
+<gcds-footer
 ```
 
 **Violations:**
 - ❌ **Fail**: Sub-footer band missing (Terms, Privacy, and Wordmark are mandatory on all page types)
 - ❌ **Fail**: Privacy link missing from sub-footer
 - ❌ **Fail**: Terms and Conditions link missing from sub-footer
+- ⚠️ **Warning**: Social media link missing from sub-footer (mandatory on standard pages)
+- ⚠️ **Warning**: Mobile applications link missing from sub-footer (mandatory on standard pages)
+- ⚠️ **Warning**: About Canada.ca link missing from sub-footer (mandatory on standard pages)
 - ⚠️ **Warning**: Main footer band missing (mandatory on standard pages)
 - ⚠️ **Warning**: "All contacts" link missing from main footer band
 - ⚠️ **Warning**: "Departments and agencies" link missing from main footer band
@@ -431,6 +490,8 @@ href="*/government/system*", href="*/gouvernement/systeme*"
 
 Generate a structured compliance report.
 
+**Strict mode:** if `branding.strictMode` is `true` in the loaded config, elevate every ⚠️ **Warning** to ❌ **Fail** when computing the Overall Status — any finding then produces an overall FAIL (useful for CI/CD gates). Note in the report header that strict mode was applied.
+
 **Report Format:**
 
 ```markdown
@@ -439,6 +500,7 @@ Generate a structured compliance report.
 ### Summary
 
 **Overall Status:** [PASS / FAIL / WARNINGS ONLY]
+**Strict Mode:** [On / Off]
 
 | Category | Status | Issues |
 |----------|--------|--------|
@@ -459,10 +521,10 @@ Generate a structured compliance report.
 
 | Status | File | Issue Found | Recommended Action |
 |--------|------|-------------|-------------------|
-| ❌ **Fail** | `src/Footer.tsx:15` | Canada Wordmark missing from footer | Add the `CanadaWordmark` component or `<img src="/images/gc-wordmark.svg" alt="Symbol of the Government of Canada">` to the footer, positioned bottom-right |
-| ❌ **Fail** | `src/Header.tsx` | Language toggle missing | Add `LanguageToggle` component with EN/FR links |
-| ⚠️ **Warning** | `styles/theme.css:42` | Custom link color `#1a73e8` | Replace with GC Design System token `--gc-color-link` (#284162) |
-| ⚠️ **Warning** | `src/Alert.tsx` | Custom Alert component | Consider using GC Design System Alert pattern |
+| ❌ **Fail** | `src/Footer.tsx:15` | Canada Wordmark missing from footer | Add `<gcds-footer>` or the `CanadaWordmark` component or `<img src="/images/gc-wordmark.svg" alt="Symbol of the Government of Canada">` to the footer, positioned bottom-right |
+| ❌ **Fail** | `src/Header.tsx` | Language toggle missing | Add `<gcds-lang-toggle>` or a `LanguageToggle` component with EN/FR links |
+| ⚠️ **Warning** | `styles/theme.css:42` | Custom link color `#1a73e8` | Replace with the Canada.ca link colour `#284162` or the corresponding GCDS token |
+| ⚠️ **Warning** | `src/Alert.tsx` | Custom Alert component | Consider using the GC Alert pattern or a GCDS component |
 | ✅ **Pass** | `src/Header.tsx` | GC Signature correctly placed | None |
 
 ---
@@ -474,8 +536,11 @@ Generate a structured compliance report.
 ### References
 
 - [Federal Identity Program Manual](https://www.canada.ca/en/treasury-board-secretariat/services/government-communications/federal-identity-program/manual.html)
+- [Design Standard for the Federal Identity Program — Colour](https://www.canada.ca/en/treasury-board-secretariat/services/government-communications/design-standard/colour-design-standard-fip.html)
 - [Canada.ca Mandatory Elements](https://design.canada.ca/specifications/mandatory-elements.html)
-- [GC Design System](https://design.canada.ca/)
+- [Canada.ca design system](https://design.canada.ca/) — Canada.ca specifications and design patterns
+- [GC Design System (GCDS)](https://design-system.canada.ca/) — component and design-token library (stable v1.0.0; the former alpha URL redirects here)
+- [GCDS Design Tokens](https://design-system.canada.ca/en/styles/design-tokens/)
 - [Typography Spec](https://design.canada.ca/styles/typography.html)
 - [Colour Spec](https://design.canada.ca/styles/colours.html)
 - [Global Header](https://design.canada.ca/common-design-patterns/global-header.html)
@@ -488,7 +553,7 @@ Generate a structured compliance report.
 | Icon | Level | Description | Action Required |
 |------|-------|-------------|-----------------|
 | ❌ | **Fail** | Mandatory FIP/policy violation | Must fix before deployment |
-| ⚠️ | **Warning** | Deviation from GC Design System | Should fix, may affect UX consistency |
+| ⚠️ | **Warning** | Deviation from GC design specifications | Should fix, may affect UX consistency |
 | ✅ | **Pass** | Compliant with standards | No action needed |
 
 ## Reference: Page Type Variations
@@ -498,12 +563,13 @@ Requirements vary by page type. When reviewing, consider which type applies:
 | Element | Standard Pages | Transactional Pages | Campaign Pages |
 |---------|---------------|---------------------|----------------|
 | GC Signature | Mandatory | Mandatory | Mandatory |
+| Signature link to Canada.ca home | Mandatory | Optional | Mandatory |
 | Language Toggle | Mandatory | Mandatory (omit only if data loss) | Mandatory |
 | Site Search Box | Mandatory | Optional | Mandatory |
 | Theme/Topic Menu | Mandatory | Optional | Optional |
 | Breadcrumb | Mandatory | Optional | Mandatory |
 | Main Footer Band | Mandatory | Optional | Optional |
-| Sub-footer Band | Mandatory | Mandatory | Mandatory |
+| Sub-footer Band | Mandatory (full link set) | Mandatory (Terms + Privacy minimum) | Mandatory (Terms + Privacy minimum) |
 | Canada Wordmark | Mandatory | Mandatory | Mandatory |
 
 ## Reference: Quick Compliance Checklist
@@ -511,17 +577,20 @@ Requirements vary by page type. When reviewing, consider which type applies:
 Use this checklist for rapid verification:
 
 ### Header Requirements
-- [ ] Government of Canada Signature (top-left, linked to Canada.ca home)
+- [ ] Government of Canada Signature (top-left, linked to Canada.ca home — link optional on transactional pages)
 - [ ] Language toggle (EN/FR)
 - [ ] Site search box (standard pages)
 - [ ] Breadcrumb trail starting with "Canada.ca" (standard pages)
 - [ ] White background
 - [ ] Divider line
 
-### Sub-footer Requirements (all page types)
-- [ ] Canada Wordmark (bottom-right)
-- [ ] Privacy link
-- [ ] Terms and Conditions link
+### Sub-footer Requirements
+- [ ] Canada Wordmark (bottom-right) — all page types
+- [ ] Privacy link — all page types
+- [ ] Terms and Conditions link — all page types
+- [ ] Social media link — standard pages
+- [ ] Mobile applications link — standard pages
+- [ ] About Canada.ca link — standard pages
 
 ### Main Footer Band (standard pages)
 - [ ] All contacts link
@@ -531,9 +600,9 @@ Use this checklist for rapid verification:
 ### Design Requirements
 - [ ] Lato font for headings (bold)
 - [ ] Noto Sans font for body text
-- [ ] GC Design System color tokens
-- [ ] H1 red bar accent (#A62A1E, 72px x 6px)
-- [ ] Standard GC components (not custom)
+- [ ] Canada.ca colours (plain hex) or GCDS `--gcds-*` tokens
+- [ ] H1 red bar accent (#A62A1E, 72px x 6px, 7.6px below the H1)
+- [ ] Standard GC components (GCDS `<gcds-*>` components are automatically compliant)
 - [ ] Date Modified in YYYY-MM-DD format
 - [ ] Text line length ≤ 65 characters
 
@@ -561,3 +630,13 @@ Your goal is to **ensure GC branding compliance** and **help developers meet fed
 4. References the relevant policy or guideline
 
 The best branding review is one where the developer leaves with clear, actionable steps to achieve compliance.
+
+## Disclaimer / <span lang="fr">Avis de non-responsabilité</span>
+
+This is an automated pattern-based review and does not constitute a formal Federal Identity Program compliance assessment. Findings should be validated by your department's communications team before being used for compliance reporting.
+
+<div lang="fr">
+
+Il s'agit d'une revue automatisée fondée sur la reconnaissance de motifs et non d'une évaluation officielle de conformité au Programme de coordination de l'image de marque. Les constatations doivent être validées par l'équipe des communications de votre ministère avant d'être utilisées à des fins de rapport de conformité.
+
+</div>


### PR DESCRIPTION
Implements all recommendations (R1–R10) from the efficacy audit of the `gc-review-branding` skill.

**Audit source:** `.gc-review/efficacy-audit/gc-review-branding.md` (not committed). FIP colours verified from a saved copy of the official Design Standard colour page, dated 2021-12-13. Policy citations verified 2026-07-10.

| R# | Change |
|----|--------|
| R1 | Fixed FIP symbol colours to Table 1 of the official Design Standard: FIP red = Pantone 032 / CMYK 0,100,100,0 / RGB 235,45,55 (≈ `#EB2D37`); Black process black; White process white; added Pewter grey Pantone 429 / RGB 150,150,150 (ministerial signatures). Noted `#FF0000` is not the official value. `#A62A1E` kept only as the Canada.ca H1 red-bar/accent colour (Steps 6–8). |
| R2 | Removed all fabricated `--gc-*` CSS variables; remediation guidance now references plain hex or real GCDS `--gcds-*` design tokens (design-system.canada.ca, `@cdssnc/gcds-tokens`). |
| R3 | Added GCDS recognition throughout Steps 4, 5, 5b, 8, 9: `<gcds-signature>`, `<gcds-header>`, `<gcds-footer>`, `<gcds-breadcrumbs>`, `<gcds-search>`, `<gcds-lang-toggle>`, `<gcds-button>`, `<gcds-date-modified>`, `<gcds-top-nav>` and `@cdssnc/gcds-components` imports are automatically compliant. References now distinguish the Canada.ca design system (design.canada.ca) from the GC Design System (design-system.canada.ca, stable v1.0.0). |
| R4 | Completed the standard-page sub-footer link set: Social media / Médias sociaux, Mobile applications / Applications mobiles, About Canada.ca / À propos de Canada.ca (Terms + Privacy remain the minimum on transactional/campaign pages). |
| R5 | Softened statically-unverifiable positional Fails (signature top-left, wordmark bottom-right) to ⚠️ Warning "could not be confirmed from code — verify visually"; ❌ Fail kept only for missing signature/wordmark. Added the "indicative, not literal regex" sentence globally and on every pattern block. |
| R6 | Added the transactional-page exemption: the signature's link to the Canada.ca home page is optional on transactional pages (also reflected in the page-type matrix and checklist). |
| R7 | Wired up `additionalFonts` (Step 6) and `strictMode` (Step 10 warning-elevation); Step 1 now rejects configs without `"version": 1`; README branding config table synced (now includes `additionalFonts`, `strictMode`). |
| R8 | Fixed French footer label: "Tous les coordonnées" → "Toutes les coordonnées". |
| R9 | Added statute citation (issued under s. 7 of the *Financial Administration Act* / *Loi sur la gestion des finances publiques*, R.S.C. 1985, c. F-11), requirement 4.1.13 effective 2026-03-27 note, EN + FR instrument titles, and `**Last Verified:** 2026-07-10`. |
| R10 | H1 red bar position corrected to "7.6px below the H1" (was "0.2em"); Bootstrap "Muted `#6c757d`" removed from the GC palette and marked as a non-GC convenience value; References retitled ("Canada.ca design system" vs "GC Design System (GCDS)") with FIP colour page and GCDS token links added. |

**Repo-convention changes bundled in:** all branding config options moved under the `"branding"` namespace in `.gc-review/config.json`; `excludePatterns` renamed to `exclude` (matching gc-review-im); bilingual disclaimer added as the final block of SKILL.md (in addition to the report template).

**Deferred:** none — all ten recommendations implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)