### PR TITLE
gc-review-iam: implement efficacy-audit recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ Vérifie les schémas de bases de données et le code d'accès aux données pour
 </div>
 
 ### `gc-review-iam`
-Reviews authentication implementations for GoC identity standards. Checks OIDC configuration, session security, scope minimization, and RBAC integration against the Directive on Identity Management and Standard on Identity and Credential Assurance.
+Reviews authentication implementations for GoC identity standards. Checks OIDC configuration, OAuth protocol security (PKCE, state/nonce, redirect URIs), MFA enforcement, session security, token validation, scope minimization, and RBAC integration against the Directive on Identity Management (including Appendix A: Standard on Identity and Credential Assurance), ITSG-33, and ITSP.30.031.
 
 <div lang="fr">
 
-Vérifie les implémentations d'authentification selon les normes d'identité du GC. Contrôle la configuration OIDC, la sécurité des sessions, la minimisation des portées et l'intégration RBAC selon la Directive sur la gestion de l'identité et la Norme sur l'assurance de l'identité et des justificatifs.
+Vérifie les implémentations d'authentification selon les normes d'identité du GC. Contrôle la configuration OIDC, la sécurité du protocole OAuth (PKCE, state/nonce, URI de redirection), l'application de l'authentification multifacteur, la sécurité des sessions, la validation des jetons, la minimisation des portées et l'intégration RBAC selon la Directive sur la gestion de l'identité (y compris l'annexe A : Norme sur l'assurance de l'identité et des justificatifs), l'ITSG-33 et l'ITSP.30.031.
 
 </div>
 
@@ -145,17 +145,45 @@ EOF
 
 #### `gc-review-iam`
 
+All options live under the `"iam"` namespace.
+
 | Field | Type | Description |
 |-------|------|-------------|
-| `additionalIdPs` | `array` | Additional approved identity providers beyond the defaults (Entra ID, GCKey, Sign-In Canada). Each entry has `name` and `issuer` fields. |
+| `iam.additionalIdPs` | `array` | Additional recognized identity providers beyond the defaults (GCKey, GCCF federation broker, CanadaLogin, enterprise directory/Entra ID surface). Each entry has `name` and `issuer` fields. |
+| `iam.assuranceLevel` | `number` | Level of Assurance (1–4) per Appendix A of the Directive on Identity Management. Drives session-lifetime ceilings (ITSP.30.031 v3) and MFA enforcement checks. |
+| `iam.publicFacing` | `boolean` | Declares a public-facing service. Consumer IdPs then produce a ⚠️ Warning (verify GCCF/CanadaLogin brokering) instead of a ❌ Fail. |
+| `iam.strictMode` | `boolean` | When true, warnings are treated as failures (equivalent to `--strict`). |
 
 ```json
 {
-  "additionalIdPs": [
-    { "name": "Departmental ADFS", "issuer": "adfs.department.gc.ca" }
-  ]
+  "version": 1,
+  "iam": {
+    "additionalIdPs": [
+      { "name": "Departmental ADFS", "issuer": "adfs.department.gc.ca" }
+    ],
+    "assuranceLevel": 2,
+    "publicFacing": false,
+    "strictMode": false
+  }
 }
 ```
+
+See [`skills/gc-review-iam/CONFIG.md`](skills/gc-review-iam/CONFIG.md) for the full schema.
+
+<div lang="fr">
+
+Toutes les options se trouvent sous l'espace de noms `"iam"`.
+
+| Champ | Type | Description |
+|-------|------|-------------|
+| `iam.additionalIdPs` | `array` | Fournisseurs d'identité reconnus supplémentaires au-delà des services par défaut (CléGC, courtier de fédération GCCF, CanadaLogin, annuaire d'entreprise/Entra ID). Chaque entrée comporte les champs `name` et `issuer`. |
+| `iam.assuranceLevel` | `number` | Niveau d'assurance (1–4) selon l'annexe A de la Directive sur la gestion de l'identité. Détermine les plafonds de durée de session (ITSP.30.031 v3) et les vérifications d'authentification multifacteur. |
+| `iam.publicFacing` | `boolean` | Déclare un service destiné au public. Les fournisseurs d'identité grand public produisent alors un avertissement ⚠️ (vérifier le courtage GCCF/CanadaLogin) au lieu d'un échec ❌. |
+| `iam.strictMode` | `boolean` | Si vrai, les avertissements sont traités comme des échecs (équivalent à `--strict`). |
+
+Voir [`skills/gc-review-iam/CONFIG.md`](skills/gc-review-iam/CONFIG.md) pour le schéma complet.
+
+</div>
 
 #### `gc-review-im`
 

--- a/skills/gc-review-iam/CONFIG.md
+++ b/skills/gc-review-iam/CONFIG.md
@@ -1,0 +1,229 @@
+# gc-review-iam Configuration
+
+This document describes the configuration schema for the `gc-review-iam` skill.
+
+## Configuration File Location
+
+**Project config:**
+```
+.gc-review/config.json
+```
+
+If no config exists, default settings are used.
+
+All gc-review-iam options live under the `"iam"` namespace.
+
+---
+
+## Configuration Schema
+
+```json
+{
+  "version": 1,
+  "iam": {
+    "additionalIdPs": [
+      { "name": "Departmental ADFS", "issuer": "adfs.department.gc.ca" }
+    ],
+    "assuranceLevel": 2,
+    "publicFacing": false,
+    "strictMode": false
+  }
+}
+```
+
+---
+
+## Field Definitions
+
+### version
+**Type:** `number`
+**Required:** Yes
+**Description:** Configuration schema version. Currently `1`.
+
+```json
+{
+  "version": 1
+}
+```
+
+---
+
+### iam.additionalIdPs
+**Type:** `array` of `{ "name": string, "issuer": string }`
+**Required:** No
+**Default:** `[]`
+**Description:** Additional recognized identity providers beyond the GC enterprise services the skill recognizes by default (GCKey `clegc-gckey.gc.ca`, GCCF broker `fjgc-gccf.gc.ca`, CanadaLogin `login.canada.ca` / `app.login-connexion.canada.ca`, and the enterprise directory surface `login.microsoftonline.com`). Use this for legitimate departmental or provincial IdPs (e.g., departmental ADFS, GCpass).
+
+Note: the Government of Canada does not publish a designated allow-list of identity providers. The binding requirement is the *Directive on Identity Management* / *Directive sur la gestion de l'identité*, s. 4.1.9 (effective 2019-07-01) — use mandatory GC enterprise identity, credential, and cyber-authentication services rather than custom credential stores. Entries here declare providers your department has accepted; they do not confer GC-wide approval.
+
+**Example:**
+```json
+{
+  "version": 1,
+  "iam": {
+    "additionalIdPs": [
+      { "name": "Departmental ADFS", "issuer": "adfs.department.gc.ca" },
+      { "name": "GCpass", "issuer": "gcpass.ssc-spc.gc.ca" }
+    ]
+  }
+}
+```
+
+---
+
+### iam.assuranceLevel
+**Type:** `number` (1–4)
+**Required:** No
+**Default:** undeclared
+**Description:** The service's Level of Assurance (LoA) per Appendix A of the Directive on Identity Management (*Standard on Identity and Credential Assurance* / *Norme sur l'assurance de l'identité et des justificatifs*). Drives two checks:
+
+- **Session timeout (Check 5.2):** assertion-lifetime ceilings per ITSP.30.031 v3 — ≤ 12 hours single-domain at LoA 1–2; ≤ 30 minutes single-domain and ≤ 5 minutes cross-domain at LoA 3. When undeclared, the skill uses an 8-hour heuristic default (not a policy value).
+- **MFA enforcement (Check 4.1):** MFA is mandatory at LoA 3 and above per ITSP.30.031 v3; missing MFA at LoA 3+ is a ❌ Fail.
+
+```json
+{
+  "version": 1,
+  "iam": {
+    "assuranceLevel": 3
+  }
+}
+```
+
+---
+
+### iam.publicFacing
+**Type:** `boolean`
+**Required:** No
+**Default:** undeclared (the skill infers from context)
+**Description:** Declares whether the application is a public-facing service. Affects Check 3.1 severity for consumer identity providers:
+
+- `true` (public-facing): consumer IdPs (Google, Facebook, GitHub, Auth0) produce a ⚠️ Warning — verify sign-in is brokered through GCCF/CanadaLogin (GCKey, Interac Sign-In Partners) rather than integrated directly.
+- `false` (internal/Protected B): consumer IdPs produce a ❌ Fail.
+
+```json
+{
+  "version": 1,
+  "iam": {
+    "publicFacing": true
+  }
+}
+```
+
+---
+
+### iam.strictMode
+**Type:** `boolean`
+**Required:** No
+**Default:** `false`
+**Description:** When enabled, all ⚠️ Warning findings are promoted to ❌ Fail in the report. Equivalent to invoking the skill with `--strict` (either enables strict mode).
+
+```json
+{
+  "version": 1,
+  "iam": {
+    "strictMode": true
+  }
+}
+```
+
+---
+
+## Complete Example Configurations
+
+### Minimal Project Config
+
+```json
+{
+  "version": 1,
+  "iam": {
+    "publicFacing": true
+  }
+}
+```
+
+### Internal Protected B Application
+
+```json
+{
+  "version": 1,
+  "iam": {
+    "assuranceLevel": 3,
+    "publicFacing": false,
+    "strictMode": true,
+    "additionalIdPs": [
+      { "name": "Departmental ADFS", "issuer": "adfs.department.gc.ca" }
+    ]
+  }
+}
+```
+
+---
+
+## Validation Rules
+
+### File Existence
+1. Check if config file exists
+2. If missing, use defaults
+
+### JSON Validation
+```bash
+# Validate JSON syntax
+jq empty .gc-review/config.json 2>&1
+```
+
+If invalid JSON:
+```
+⚠️  Invalid JSON in .gc-review/config.json: {error}
+Using default configuration.
+```
+
+### Field Validation
+
+| Field | Validation |
+|-------|------------|
+| `version` | Must be number, currently `1` |
+| `iam.additionalIdPs` | Must be array of objects with string `name` and `issuer` |
+| `iam.assuranceLevel` | Must be number 1–4 |
+| `iam.publicFacing` | Must be boolean |
+| `iam.strictMode` | Must be boolean |
+
+### Invalid Field Handling
+
+If a field has invalid type:
+```
+⚠️  Invalid config: {field} must be {expected_type}, got {actual_type}
+Using default value for {field}.
+```
+
+### Unknown Field Handling
+
+Unknown fields are ignored with a warning:
+```
+⚠️  Unknown config field: {field_name} (ignored)
+```
+
+---
+
+## Config Resolution
+
+```
+.gc-review/config.json exists → use project config (iam namespace)
+.gc-review/config.json missing → use default configuration
+```
+
+---
+
+## Setting Up Configuration
+
+```bash
+mkdir -p .gc-review
+cat > .gc-review/config.json << 'EOF'
+{
+  "version": 1,
+  "iam": {
+    "assuranceLevel": 2,
+    "publicFacing": false
+  }
+}
+EOF
+```

--- a/skills/gc-review-iam/SKILL.md
+++ b/skills/gc-review-iam/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gc-review-iam
-description: Review code for Government of Canada authentication and identity management compliance. Checks OIDC implementations, session security, scope minimization, logout handling, and RBAC integration against ITSG-33 and TBS security standards.
+description: Review code for Government of Canada authentication and identity management compliance. Checks OIDC implementations, OAuth protocol security (PKCE, state/nonce, redirect URIs), MFA enforcement, session security, token validation, scope minimization, logout handling, and RBAC integration against ITSG-33, ITSP.30.031 and TBS identity standards.
 allowed-tools: Read, Grep, Glob, Bash
 ---
 
@@ -11,36 +11,80 @@ You are a **Government of Canada Identity and Access Management (IAM) Specialist
 ## Standards Reference
 
 Your reviews are based on:
-- **ITSG-33** (updated 2023-03-01) - IT Security Risk Management (Identification and Authentication controls)
-- **Standard on Identity and Credential Assurance** - Credential management and authentication assurance levels (Appendix A, Directive on Identity Management, effective 2019-07-01)
-- **TBS Guideline on Defining Authentication Requirements** - Authentication assurance levels
-- **Privacy Act** (R.S.C. 1985, c. P-21) - Protection of personal information
-- **Directive on Service and Digital** (effective 2020-04-01) - Digital identity requirements
+- **ITSG-33 — IT Security Risk Management: A Lifecycle Approach** / *La gestion des risques liés à la sécurité des TI : Une méthode axée sur le cycle de vie (ITSG-33)* (CCCS, November 2012; Annex 3A security control catalogue, December 2014 — information remains valid) — Identification and Authentication controls
+- **ITSP.30.031 v3 — User Authentication Guidance for Information Technology Systems** / *Guide sur l'authentification des utilisateurs dans les systèmes de technologies de l'information (ITSP.30.031 v3)* (CCCS, April 2018) — assurance levels, multi-factor authentication, assertion lifetimes
+- **Directive on Identity Management** / *Directive sur la gestion de l'identité* (effective 2019-07-01) — including **Appendix A: Standard on Identity and Credential Assurance** / *annexe A : Norme sur l'assurance de l'identité et des justificatifs* — credential management and authentication assurance levels
+- **TBS Guideline on Defining Authentication Requirements** / *Ligne directrice sur la définition des exigences en matière d'authentification* (TBS, November 2012) — authentication assurance levels; predates and should be read alongside ITSP.30.031 v3
+- **Guideline on Cloud Authentication** / *Ligne directrice sur l'authentification infonuagique* — cloud-console authentication configuration; consult TBS Cyber Security Division for bespoke solutions
+- **Directive on Security Management** / *Directive sur la gestion de la sécurité* (effective 2019-07-01) — Appendix B (IT security controls)
+- **Privacy Act** (R.S.C. 1985, c. P-21) / *Loi sur la protection des renseignements personnels* (L.R.C. 1985, ch. P-21) — protection of personal information
+- **Directive on Service and Digital** / *Directive sur les services et le numérique* (effective 2020-04-01; minor amendments 2025-08-29) — digital identity requirements
+- **RFC 9700 — OAuth 2.0 Security Best Current Practice** (IETF, January 2025), **RFC 7636 (PKCE)**, **RFC 8725 (JWT BCP)**, **OpenID Connect Core 1.0** — protocol-level security requirements
 
-**Last Verified:** 2026-03-11
+**Last Verified:** 2026-07-10
 
-## Authorized Identity Providers
+## Identity Providers
 
-The following identity providers are approved by default for Government of Canada applications:
-- **Microsoft Entra ID** (formerly Azure AD) - `login.microsoftonline.com`
-- **GCKey** - `clegc-gckey.gc.ca`
-- **Sign-In Canada** - Government federated identity service
+The Government of Canada does **not** publish a designated allow-list of identity providers. The binding requirement is the *Directive on Identity Management* (*Directive sur la gestion de l'identité*), subsection 4.1.9 (effective 2019-07-01): departments must use the **mandatory GC enterprise services for identity management, credential management and cyber authentication** rather than application-specific credential stores. The compliance risk to flag is a **custom or self-built credential store** — not the absence of a specific product.
 
-Projects may specify additional approved providers in `.gc-review/config.json`:
+What is actually in use, per the **GC ICAM Framework v1.1** (2022-01-28; guidance, not policy):
+
+**External / public-facing** — federation is mandatory for new deployments, via Shared Services Canada's GC Credential Federation (GCCF, broker paths on `fjgc-gccf.gc.ca`):
+- **GCKey** (`clegc-gckey.gc.ca`) — the universal self-service credential for external users
+- **Interac Sign-In Partners** — financial-institution credentials
+- **Provincial credentials** (Alberta, British Columbia) via GCCF
+- **CanadaLogin** (`login.canada.ca`, `app.login-connexion.canada.ca`) — launched 2025 by CDS/ESDC; carries forward GCKey/Interac sign-ins; new external integrations should target GCCF/CanadaLogin
+- **Sign In Canada** — **maintenance-only since 2023-07-31** (no new applications); its successor is CanadaLogin
+
+**Internal / workforce:**
+- **SSC/departmental Active Directory** — commonly surfaced as Microsoft Entra ID in cloud (`login.microsoftonline.com`). Note: **Entra ID is not formally "approved" by name in any GC instrument**; it is accepted as the cloud surface of the enterprise directory.
+- **ICM PKI (myKEY)** — internal PKI credential
+- **GCpass** — SSC internal federation broker
+
+For cloud-console authentication configuration, follow the *Guideline on Cloud Authentication* and consult the TBS Cyber Security Division before building bespoke authentication solutions.
+
+Projects may specify additional recognized providers and review options in `.gc-review/config.json` (all IAM options live under the `"iam"` namespace):
 ```json
 {
   "version": 1,
-  "additionalIdPs": [
-    { "name": "Departmental ADFS", "issuer": "adfs.department.gc.ca" }
-  ]
+  "iam": {
+    "additionalIdPs": [
+      { "name": "Departmental ADFS", "issuer": "adfs.department.gc.ca" }
+    ],
+    "assuranceLevel": 2,
+    "publicFacing": false,
+    "strictMode": false
+  }
 }
 ```
+
+See `skills/gc-review-iam/CONFIG.md` for the full configuration schema.
 
 ---
 
 ## Workflow
 
 Execute these steps in order:
+
+### Step 0: Parse Arguments & Load Configuration
+
+**1. Parse arguments:**
+- If the invocation includes `--strict`, set strict mode ON for this run.
+- Any remaining arguments are treated as file/glob scopes for the review.
+
+**2. Load project configuration:**
+
+```bash
+cat .gc-review/config.json 2>/dev/null
+```
+
+- If the file exists, validate JSON (`jq empty .gc-review/config.json`) and require `"version": 1`. Read the `"iam"` object: `additionalIdPs`, `assuranceLevel`, `publicFacing`, `strictMode`.
+- If `iam.strictMode` is `true`, set strict mode ON (the `--strict` flag and config are equivalent; either enables it).
+- If the file is missing or invalid, use defaults: no additional IdPs, `assuranceLevel` undeclared, `publicFacing` unknown, strict mode OFF (unless `--strict` was passed).
+
+**3. Apply strict mode:** when strict mode is ON, promote every ⚠️ **Warning** finding to ❌ **Fail** in the final report (Step 9), and note "Strict mode: ON" in the report header.
+
+Proceed to Step 1.
 
 ### Step 1: Detect Project Context
 
@@ -115,7 +159,7 @@ grep -rl --include="*.ts" --include="*.js" --include="*.py" --include="*.cs" --i
   -e "openid\|oidc\|oauth" \
   -e "clientId\|clientSecret\|client_id\|client_secret" \
   -e "httpOnly\|HttpOnly\|SameSite" \
-  -e "GCKey\|Entra\|AzureAD" \
+  -e "GCKey\|Entra\|AzureAD\|CanadaLogin\|login.canada.ca\|fjgc-gccf" \
   . 2>/dev/null | grep -v node_modules | grep -v vendor
 ```
 
@@ -139,13 +183,15 @@ find . -type f \( \
 
 Read each identified file before proceeding to Step 3.
 
-### Step 3: OIDC Implementation Standards Review
+### Step 3: OIDC Implementation & Protocol Security Review
 
-Review authentication configuration against OIDC best practices.
+Review authentication configuration against OIDC and OAuth 2.0 security best practices.
 
-#### Check 3.1: Authorized Identity Providers
+> Detection patterns below are indicative, not literal regex — read the surrounding code for context before reporting.
 
-**Requirement:** Only use GoC-approved identity providers.
+#### Check 3.1: Identity Providers
+
+**Requirement:** Use GC enterprise identity services (*Directive on Identity Management*, s. 4.1.9) rather than application-specific or custom credential stores.
 
 **Search for IdP configuration:**
 ```regex
@@ -153,22 +199,30 @@ issuer|authority|identityProvider|authorizationUrl|tokenUrl
 ```
 
 **Pass criteria:**
-- Issuer URL contains `login.microsoftonline.com` (Entra ID)
-- Issuer URL contains `clegc-gckey.gc.ca` (GCKey)
-- Uses Sign-In Canada federation
+- Issuer URL matches a recognized GC service:
+  - `clegc-gckey.gc.ca` (GCKey)
+  - `fjgc-gccf.gc.ca` (GCCF federation broker — Interac Sign-In Partners, provincial credentials)
+  - `login.canada.ca` or `app.login-connexion.canada.ca` (CanadaLogin)
+  - `login.microsoftonline.com` (Entra ID — enterprise directory surface for internal/workforce apps)
+- Issuer matches an entry in `iam.additionalIdPs` from `.gc-review/config.json`
+- Issuer validation is enabled
 
 **Fail patterns:**
-- Generic consumer OAuth providers (Google: `accounts.google.com`, Facebook, GitHub, Auth0)
+- Custom or self-built credential store (local password table, bespoke login/registration) for a GC service — this is the primary s. 4.1.9 compliance risk
+- Generic consumer OAuth providers (Google: `accounts.google.com`, Facebook, GitHub, Auth0) in an **internal or Protected B** application
 - Missing issuer validation
 
 **Warning patterns:**
-- Unknown/custom identity providers not in the approved list — flag as Warning and request justification rather than failing outright, as departments may use legitimate internal IdPs (e.g., departmental ADFS, provincial federation services)
+- Generic consumer OAuth providers in a **public-facing** service (`iam.publicFacing: true` in config, or the service is evidently public) — ⚠️ Warning: verify the sign-in is brokered through GCCF/CanadaLogin (e.g., Interac Sign-In Partners) rather than integrated directly
+- Unknown/custom identity providers not recognized above — flag as Warning and request justification rather than failing outright, as departments may use legitimate internal IdPs (e.g., departmental ADFS, GCpass, provincial federation services)
 
 **Finding format:**
 ```
 | Status | File | Issue Found | Recommended Action |
-| ❌ **Fail** | {file}:{line} | [Auth Error] Consumer identity provider: {provider} | Use Entra ID, GCKey, or Sign-In Canada as per TBS guidelines |
-| ⚠️ **Warning** | {file}:{line} | [Auth Warning] Unrecognized identity provider: {provider} | Verify this is a GoC-approved IdP. If approved, add to .gc-review/config.json additionalIdPs |
+| ❌ **Fail** | {file}:{line} | [Auth Error] Custom credential store detected | Use GC enterprise identity services (GCCF/CanadaLogin external; enterprise directory internal) per Directive on Identity Management s. 4.1.9 |
+| ❌ **Fail** | {file}:{line} | [Auth Error] Consumer identity provider in internal/Protected B app: {provider} | Use the GC enterprise directory (Entra ID surface) or GCCF federation |
+| ⚠️ **Warning** | {file}:{line} | [Auth Warning] Consumer identity provider in public-facing service: {provider} | Broker external sign-in through GCCF/CanadaLogin (GCKey, Interac Sign-In Partners) instead of direct integration |
+| ⚠️ **Warning** | {file}:{line} | [Auth Warning] Unrecognized identity provider: {provider} | Verify this is a legitimate departmental/enterprise IdP. If so, add to .gc-review/config.json under iam.additionalIdPs |
 ```
 
 #### Check 3.2: Hardcoded Secrets
@@ -222,11 +276,122 @@ authorization_endpoint|token_endpoint|userinfo_endpoint|jwks_uri
 | ⚠️ **Warning** | {file}:{line} | Hardcoded OIDC endpoint instead of using discovery | Use wellKnown endpoint for automatic configuration |
 ```
 
-### Step 4: Session Security Review
+#### Check 3.4: PKCE (Proof Key for Code Exchange)
+
+**Requirement:** PKCE (RFC 7636) must be used by **all** authorization-code clients per RFC 9700 (OAuth 2.0 Security Best Current Practice, January 2025).
+
+**Search patterns:**
+```regex
+code_challenge|code_verifier|codeChallenge|codeVerifier|usePKCE|pkce
+```
+
+**Pass criteria:**
+- Authorization-code flow configured with PKCE (`code_challenge_method=S256`)
+- Auth library enables PKCE by default and it is not disabled
+
+**Fail patterns:**
+- Public client (SPA, mobile, desktop) using authorization-code flow without PKCE
+- PKCE explicitly disabled (`usePKCE: false`, `disablePkce`)
+- `code_challenge_method=plain` (S256 required)
+
+**Warning patterns:**
+- Confidential (server-side) client using authorization-code flow without PKCE
+
+**Finding format:**
+```
+| ❌ **Fail** | {file}:{line} | [Auth Error] Public client without PKCE | Enable PKCE with S256 code challenge (RFC 7636 / RFC 9700) |
+| ⚠️ **Warning** | {file}:{line} | Confidential client without PKCE | Enable PKCE for defense in depth per RFC 9700 |
+```
+
+#### Check 3.5: State & Nonce Validation
+
+**Requirement:** Validate the OAuth `state` parameter (CSRF protection) and the OIDC `nonce` claim (replay protection) per RFC 9700 and OpenID Connect Core 1.0.
+
+**Search patterns:**
+```regex
+state|nonce|checks\s*[:=]|state:\s*false|skipStateCheck
+```
+
+**Pass criteria:**
+- `state` generated per request, bound to the session, and verified on callback
+- `nonce` sent on the authentication request and validated against the ID token claim
+- Auth library performs these checks by default and they are not disabled
+
+**Fail patterns:**
+- `state` or `nonce` checks explicitly disabled (e.g., `state: false`, `checks: []`, `skipStateCheck: true`)
+- Callback handler exchanges the code without verifying `state`
+
+**Warning patterns:**
+- Cannot confirm state/nonce validation from the code (hand-rolled flow with no visible checks)
+
+**Finding format:**
+```
+| ❌ **Fail** | {file}:{line} | [Auth Error] state/nonce validation disabled | Re-enable state (CSRF) and nonce (replay) checks per RFC 9700 / OIDC Core |
+| ⚠️ **Warning** | {file}:{line} | Unable to confirm state/nonce validation | Verify the callback validates state and nonce before accepting tokens |
+```
+
+#### Check 3.6: Redirect URI Validation
+
+**Requirement:** Redirect URIs must be matched **exactly** — no wildcards, no open redirects (RFC 9700).
+
+**Search patterns:**
+```regex
+redirect_uri|redirectUri|callbackURL|post_logout_redirect|returnUrl|returnTo
+```
+
+**Pass criteria:**
+- Redirect URIs registered and compared with exact string matching
+- Post-login/post-logout redirect targets validated against an allow-list
+
+**Fail patterns:**
+- Wildcard redirect URIs (`https://*.example.com/callback`)
+- Redirect target taken from user input (query parameter, request body) without allow-list validation (open redirect)
+
+**Warning patterns:**
+- Prefix or pattern-based redirect URI matching instead of exact matching
+
+**Finding format:**
+```
+| ❌ **Fail** | {file}:{line} | [Auth Error] Open redirect / wildcard redirect URI | Register exact redirect URIs and validate all redirect targets against an allow-list (RFC 9700) |
+| ⚠️ **Warning** | {file}:{line} | Non-exact redirect URI matching | Use exact string matching for redirect URIs |
+```
+
+### Step 4: MFA Enforcement Review
+
+Review multi-factor authentication enforcement.
+
+#### Check 4.1: MFA Enforcement
+
+**Requirement:** Multi-factor authentication is mandatory at Level of Assurance 3 and above per ITSP.30.031 v3, and for GC cloud administrative/user accounts per GC Cloud Guardrail 01. Protected B applications should be treated as LoA 3+.
+
+**Search patterns:**
+```regex
+amr|acr|acr_values|ConditionalAccess|mfa|multiFactor|two_factor|2fa|totp|webauthn|fido2|authenticator
+```
+
+**Pass criteria:**
+- MFA enforced by the IdP (e.g., Entra ID Conditional Access) and documented, **or**
+- Application validates `amr`/`acr` claims to require an MFA-satisfying authentication context, **or**
+- Application implements TOTP/WebAuthn (FIDO2) second-factor flows
+
+**Fail patterns:**
+- No MFA enforcement or `amr`/`acr` validation in an application declared LoA 3+ (`iam.assuranceLevel >= 3`) or handling Protected B data
+- MFA explicitly bypassed or disabled for production paths
+
+**Warning patterns:**
+- Assurance level undeclared and no evidence of MFA enforcement — request the project declare `iam.assuranceLevel` in `.gc-review/config.json`
+
+**Finding format:**
+```
+| ❌ **Fail** | {file}:{line} | [Auth Error] No MFA enforcement for LoA 3+/Protected B application | Enforce MFA via IdP policy (e.g., Conditional Access) or validate amr/acr claims (ITSP.30.031 v3; Cloud Guardrail 01) |
+| ⚠️ **Warning** | {file}:{line} | No MFA evidence; assurance level undeclared | Declare iam.assuranceLevel in .gc-review/config.json and confirm MFA policy at the IdP |
+```
+
+### Step 5: Session Security Review
 
 Review session and cookie configuration for security compliance.
 
-#### Check 4.1: Cookie Security Flags
+#### Check 5.1: Cookie Security Flags
 
 **Requirement:** Session cookies must have HttpOnly, Secure, and SameSite flags.
 
@@ -280,44 +445,58 @@ options.Cookie.SameSite = SameSiteMode.Strict;
 | ❌ **Fail** | {file}:{line} | [Auth Error] Cookie {flag} flag is {value} | Set {flag}: true (required for Protected B data) |
 ```
 
-#### Check 4.2: Session Timeout
+#### Check 5.2: Session Timeout
 
-**Requirement:** Session timeout must not exceed 8 hours (28800 seconds) per ITSG-33.
+**Requirement:** Session/assertion lifetime must be explicitly configured and aligned to the service's assurance level per ITSP.30.031 v3 (CCCS, April 2018): assertions ≤ 12 hours single-domain at LoA 1–2; ≤ 30 minutes single-domain and ≤ 5 minutes cross-domain at LoA 3. ITSG-33 AC-12 (Session Termination) and SC-10 (Network Disconnect) require an *organization-defined* period — flag missing/unbounded timeouts as ❌ Fail and lifetimes above the LoA ceiling as ⚠️ Warning pending the project's documented assurance level.
 
 **Search patterns:**
 ```regex
 maxAge|max_age|expires|expiresIn|timeout|ttl|lifetime|PERMANENT_SESSION_LIFETIME
 ```
 
-**Calculations:**
-- 8 hours = 28800 seconds = 28800000 milliseconds = 480 minutes
+**Assurance-level ceilings (ITSP.30.031 v3):**
+
+| Level of Assurance | Single-domain assertion | Cross-domain assertion |
+|--------------------|------------------------|------------------------|
+| LoA 1–2 | ≤ 12 hours | — |
+| LoA 3 | ≤ 30 minutes | ≤ 5 minutes |
+
+**Heuristic default (not a policy value):** where the project has not declared an assurance level (`iam.assuranceLevel`), use **8 hours (28800 seconds)** as a review heuristic for internal LoA 2 sessions. This is an operational default only — it does not appear in ITSG-33 or ITSP.30.031 and must not be cited as a policy requirement.
 
 **Pass criteria:**
 - Explicit timeout configured
-- Timeout <= 8 hours
+- Lifetime at or below the ceiling for the declared (or heuristic-default) assurance level
 - Sliding expiration with absolute maximum
 
-**Fail patterns:**
-- No timeout configured (infinite session)
-- Timeout > 8 hours
+**Fail patterns (❌ Fail):**
+- No timeout configured (infinite/unbounded session)
+
+**Warning patterns (⚠️ Warning):**
+- Lifetime above the ceiling for the declared assurance level (or above the 8-hour heuristic default when no level is declared)
 - "Remember me" without reasonable cap (e.g., 30 days)
 
 **Finding format:**
 ```
-| ⚠️ **Warning** | {file}:{line} | Session timeout set to {value} (exceeds 8-hour limit) | Reduce to 28800 seconds or less per ITSG-33 |
+| ❌ **Fail** | {file}:{line} | [Auth Error] No session timeout configured (unbounded session) | Configure an explicit lifetime aligned to the assurance level (ITSP.30.031 v3; ITSG-33 AC-12/SC-10) |
+| ⚠️ **Warning** | {file}:{line} | Session lifetime {value} exceeds the LoA {level} ceiling ({ceiling}) | Reduce the lifetime or document the assurance-level justification (ITSP.30.031 v3) |
 ```
 
-#### Check 4.3: Token Storage Strategy
+#### Check 5.3: Token Storage & Validation
 
-**Requirement:** Use signed tokens (JWT) or server-side session storage.
+**Requirement:** Use signed tokens (JWT) or server-side session storage, and validate token `aud` (audience), `iss` (issuer), and signature algorithm per RFC 8725 (JWT Best Current Practices).
 
 **Pass criteria:**
 - JWTs with signature validation (RS256, ES256 preferred over HS256)
+- Token `aud` claim validated against this application's client/audience identifier
+- Token `iss` claim validated against the expected issuer
+- Explicit `alg` allow-list — `none` rejected
 - Server-side session store (Redis, database, memory cache)
 - Encrypted session data
 
 **Fail patterns:**
-- Unsigned tokens
+- Unsigned tokens, or `alg: none` accepted
+- Missing `aud` or `iss` validation (e.g., `audience` check disabled, `verify_aud: false`)
+- No algorithm allow-list (accepting whatever `alg` the token header declares)
 - Client-side only storage without server validation
 - Tokens in localStorage (XSS vulnerable)
 - Sensitive data in unencrypted cookies
@@ -325,13 +504,14 @@ maxAge|max_age|expires|expiresIn|timeout|ttl|lifetime|PERMANENT_SESSION_LIFETIME
 **Finding format:**
 ```
 | ❌ **Fail** | {file}:{line} | [Auth Error] Tokens stored in localStorage | Use httpOnly cookies or server-side session storage |
+| ❌ **Fail** | {file}:{line} | [Auth Error] Token validation missing aud/iss check or alg allow-list | Validate aud and iss; restrict alg to RS256/ES256 and reject `none` (RFC 8725) |
 ```
 
-### Step 5: Scope & Claim Minimization Review
+### Step 6: Scope & Claim Minimization Review
 
 Review OIDC scope requests and claim handling for privacy compliance.
 
-#### Check 5.1: OIDC Scope Analysis
+#### Check 6.1: OIDC Scope Analysis
 
 **Requirement:** Request only minimum necessary scopes (Privacy Act, Least Privilege).
 
@@ -359,7 +539,7 @@ scope[s]?\s*[:=]\s*["'][^"']*["']
 | ⚠️ **Warning** | {file}:{line} | Requesting '{scope}' scope but usage not detected | Reduce scopes to minimum required (Privacy Act compliance) |
 ```
 
-#### Check 5.2: Claim Handling Location
+#### Check 6.2: Claim Handling Location
 
 **Requirement:** Sensitive claims must be processed server-side only.
 
@@ -386,11 +566,11 @@ jwt_decode|jwtDecode|atob.*split|parseJwt|decodeToken
 | ❌ **Fail** | {file}:{line} | [Auth Error] JWT decoded in frontend code | Move token processing to backend API |
 ```
 
-### Step 6: Logout & Token Revocation Review
+### Step 7: Logout & Token Revocation Review
 
 Review sign-out implementation for complete session termination.
 
-#### Check 6.1: Local Session Clearing
+#### Check 7.1: Local Session Clearing
 
 **Requirement:** Complete local session invalidation on logout.
 
@@ -429,7 +609,7 @@ HttpContext.SignOutAsync()
 | ⚠️ **Warning** | {file}:{line} | Logout only clears cookie, session may persist | Add explicit session.destroy() or equivalent |
 ```
 
-#### Check 6.2: OIDC End Session Endpoint
+#### Check 7.2: OIDC End Session Endpoint
 
 **Requirement:** Call IdP End Session endpoint for federated logout.
 
@@ -453,17 +633,17 @@ end_session_endpoint|logout.*redirect|signOut.*redirect|post_logout_redirect
 | ⚠️ **Warning** | {file}:{line} | Missing OIDC End Session endpoint call | Implement federated logout via end_session_endpoint |
 ```
 
-### Step 7: RBAC Integration Review
+### Step 8: RBAC Integration Review
 
 Review role-based access control implementation for security.
 
-#### Check 7.1: Role Mapping Location
+#### Check 8.1: Role Mapping Location
 
 **Requirement:** IdP roles must be mapped to application roles server-side.
 
 **Search patterns:**
 ```regex
-roles|groups|claims.*role|hasRole|isInRole|authorize|@Roles|[Authorize]
+hasRole|isInRole|\[Authorize\]|@PreAuthorize|@Roles|requireRole|claims.*role
 ```
 
 **Pass criteria:**
@@ -481,7 +661,7 @@ roles|groups|claims.*role|hasRole|isInRole|authorize|@Roles|[Authorize]
 | ❌ **Fail** | {file}:{line} | [Auth Error] Role authorization in frontend code | Move role checks to backend middleware |
 ```
 
-#### Check 7.2: Role Manipulation Prevention
+#### Check 8.2: Role Manipulation Prevention
 
 **Requirement:** Client cannot modify or override server-determined roles.
 
@@ -505,147 +685,143 @@ req\.body\.role|request\.role|role.*header|x-user-role
 | ❌ **Fail** | {file}:{line} | [Auth Error] Roles read from client request | Source roles only from validated IdP token |
 ```
 
-### Step 8: Generate Report
+### Step 9: Generate Report
 
-Present findings in the required structured format.
+Present findings in the required structured format. If strict mode is ON (Step 0), promote every ⚠️ **Warning** finding to ❌ **Fail** before rendering the report, and state "Strict mode: ON" in the header.
 
-#### 8.1 Report Header
+#### 9.1 Report Header
 
-```
-================================================================================
-  Government of Canada - Identity & Authentication Review
-  Skill ID: GOC-AUTH-001
-================================================================================
+```markdown
+# Government of Canada — Identity & Authentication Review
 
-Project: {project name from package.json or directory}
-Files Reviewed: {count}
-Review Date: {current date}
-Technology Stack: {detected framework}
+**Skill ID:** GOC-AUTH-001
+**Project:** {project name from package.json or directory}
+**Files Reviewed:** {count}
+**Review Date:** {current date}
+**Technology Stack:** {detected framework}
+**Strict Mode:** {ON/OFF}
 
-Standards Applied:
-- ITSG-33 (Identification and Authentication)
-- Standard on Identity and Credential Assurance (Appendix A, Directive on Identity Management)
+**Standards Applied:**
+- ITSG-33 (Identification and Authentication controls)
+- ITSP.30.031 v3 (User Authentication Guidance)
+- Directive on Identity Management, Appendix A: Standard on Identity and Credential Assurance
 - TBS Guideline on Defining Authentication Requirements
 - Privacy Act (Scope Minimization)
-
---------------------------------------------------------------------------------
+- RFC 9700 / RFC 8725 (OAuth 2.0 / JWT security best practices)
 ```
 
-#### 8.2 Summary Statistics
+#### 9.2 Summary Statistics
 
-```
-REVIEW SUMMARY
-==============
+```markdown
+## Review Summary
 
 | Category | Status | Issues |
 |----------|--------|--------|
-| A. OIDC Implementation | {PASS/FAIL/WARN} | {count} |
-| B. Session Security | {PASS/FAIL/WARN} | {count} |
-| C. Scope Minimization | {PASS/FAIL/WARN} | {count} |
-| D. Logout Handling | {PASS/FAIL/WARN} | {count} |
-| E. RBAC Integration | {PASS/FAIL/WARN} | {count} |
+| A. OIDC & Protocol Security | {PASS/FAIL/WARN} | {count} |
+| B. MFA Enforcement | {PASS/FAIL/WARN} | {count} |
+| C. Session Security | {PASS/FAIL/WARN} | {count} |
+| D. Scope Minimization | {PASS/FAIL/WARN} | {count} |
+| E. Logout Handling | {PASS/FAIL/WARN} | {count} |
+| F. RBAC Integration | {PASS/FAIL/WARN} | {count} |
 
-Total: {X} Failures, {Y} Warnings, {Z} Passes
+**Total:** {X} Failures, {Y} Warnings, {Z} Passes
 ```
 
-#### 8.3 Findings Table
+#### 9.3 Findings Table
 
 Present all findings in the required table format:
 
-```
-DETAILED FINDINGS
-=================
+```markdown
+## Detailed Findings
 
 | Status | File | Issue Found | Recommended Action |
 |--------|------|-------------|-------------------|
 | ❌ **Fail** | src/auth/config.ts:15 | [Auth Error] Hardcoded client secret | Move to environment variable or Key Vault |
 | ❌ **Fail** | src/pages/login.tsx:42 | [Auth Error] JWT decoded in frontend | Move token processing to backend API |
-| ⚠️ **Warning** | src/session.ts:8 | Session timeout exceeds 8 hours | Reduce to 28800 seconds or less |
+| ❌ **Fail** | src/auth/spa-client.ts:9 | [Auth Error] Public client without PKCE | Enable PKCE with S256 code challenge |
+| ⚠️ **Warning** | src/session.ts:8 | Session lifetime exceeds the LoA 2 ceiling | Reduce lifetime or document assurance-level justification |
 | ⚠️ **Warning** | src/auth/scopes.ts:12 | Requesting 'offline_access' scope | Verify business justification for refresh tokens |
 | ✅ **Pass** | src/middleware/auth.ts | RBAC implemented server-side | None |
-| ✅ **Pass** | src/auth/oidc.ts | Using Entra ID with wellKnown endpoint | None |
+| ✅ **Pass** | src/auth/oidc.ts | Recognized GC enterprise IdP with wellKnown discovery | None |
 ```
 
-#### 8.4 Detailed Findings (for each Fail/Warning)
+#### 9.4 Detailed Findings (for each Fail/Warning)
 
-For critical failures, provide detailed remediation:
+For critical failures, provide detailed remediation using this markdown structure:
 
+````markdown
+### [Auth Error] Hardcoded Client Secret
+
+- **File:** src/auth/config.ts:15
+- **Category:** A. OIDC & Protocol Security
+- **Severity:** ❌ **Fail**
+- **Reference:** ITSG-33 IA-5 (Authenticator Management)
+
+**Code found:**
+
+```javascript
+const config = {
+  clientId: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+  clientSecret: 'abc123secret456xyz'  // <-- VIOLATION
+};
 ```
---------------------------------------------------------------------------------
-[Auth Error] Hardcoded Client Secret
---------------------------------------------------------------------------------
-File: src/auth/config.ts:15
-Category: A. OIDC Implementation Standards
-Severity: FAIL
-Reference: ITSG-33 IA-5 (Authenticator Management)
 
-Code Found:
-┌─────────────────────────────────────────────────────────────
-│ const config = {
-│   clientId: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
-│   clientSecret: 'abc123secret456xyz'  // <-- VIOLATION
-│ };
-└─────────────────────────────────────────────────────────────
+**Issue:**
+Client secrets must never be stored in source code. This violates ITSG-33
+IA-5 (Authenticator Management) and the Directive on Security Management
+(*Directive sur la gestion de la sécurité*, effective 2019-07-01),
+Appendix B (IT security controls). Exposed secrets can lead to unauthorized
+access to the identity provider and impersonation attacks.
 
-Issue:
-Client secrets must never be stored in source code. This violates
-ITSG-33 IA-5 (Authenticator Management) and TBS Standard on Security
-Tabs. Exposed secrets can lead to unauthorized access to the identity
-provider and impersonation attacks.
-
-Recommended Action:
+**Recommended action:**
 1. Remove the secret from source code immediately
 2. Store in environment variable:
-   - process.env.AZURE_CLIENT_SECRET (Node.js)
-   - os.environ['AZURE_CLIENT_SECRET'] (Python)
+   - `process.env.AZURE_CLIENT_SECRET` (Node.js)
+   - `os.environ['AZURE_CLIENT_SECRET']` (Python)
 3. For production: Use Azure Key Vault or equivalent secrets manager
-4. CRITICAL: Rotate the exposed secret in Entra ID immediately
+4. CRITICAL: Rotate the exposed secret at the identity provider immediately
 
-Remediation Example:
-┌─────────────────────────────────────────────────────────────
-│ const config = {
-│   clientId: process.env.AZURE_CLIENT_ID,
-│   clientSecret: process.env.AZURE_CLIENT_SECRET
-│ };
-└─────────────────────────────────────────────────────────────
+**Remediation example:**
 
---------------------------------------------------------------------------------
+```javascript
+const config = {
+  clientId: process.env.AZURE_CLIENT_ID,
+  clientSecret: process.env.AZURE_CLIENT_SECRET
+};
 ```
+````
 
-#### 8.5 Report Footer
+#### 9.5 Report Footer
 
-```
-================================================================================
-COMPLIANCE SUMMARY
-================================================================================
+```markdown
+## Compliance Summary
 
 {If any FAIL}:
 ⛔ This codebase has CRITICAL authentication compliance issues that must
-   be resolved before deployment. Address all [Auth Error] findings.
+be resolved before deployment. Address all [Auth Error] findings.
 
 {If only WARN}:
-⚠️  This codebase has authentication warnings that should be reviewed.
-   Consider addressing warnings to improve security posture.
+⚠️ This codebase has authentication warnings that should be reviewed.
+Consider addressing warnings to improve security posture.
 
 {If all PASS}:
 ✅ This codebase passes all Government of Canada authentication
-   compliance checks. Continue to monitor for changes.
+compliance checks. Continue to monitor for changes.
 
---------------------------------------------------------------------------------
-Next Steps:
+**Next Steps:**
 1. Address all ❌ Fail findings before proceeding
 2. Review ⚠️ Warning findings with your security team
 3. Re-run /gc-review-iam after fixes are applied
 4. Document any accepted risks with justification
 
-Disclaimer: This is an automated pattern-based review and does not constitute
-a formal Security Assessment and Authorization (SA&A). Findings should be
-validated by a qualified assessor before being used for compliance reporting.
+> **Disclaimer:** This is an automated pattern-based review and does not
+> constitute a formal Security Assessment and Authorization (SA&A).
+> Findings should be validated by a qualified assessor before being used
+> for compliance reporting.
 
 For questions about GoC authentication standards, consult:
 - CCCS Cyber Centre: https://cyber.gc.ca
 - TBS Digital Standards: https://www.canada.ca/en/government/system/digital-government
-================================================================================
 ```
 
 ---
@@ -663,7 +839,7 @@ app.use(session({
     httpOnly: true,    // Required
     secure: true,      // Required for HTTPS
     sameSite: 'strict', // Required
-    maxAge: 28800000   // 8 hours max
+    maxAge: 28800000   // 8h heuristic default (LoA 2 internal) — not a policy value; align to ITSP.30.031 v3
   },
   resave: false,
   saveUninitialized: false
@@ -697,7 +873,7 @@ export const authOptions = {
   ],
   session: {
     strategy: 'jwt',
-    maxAge: 28800  // 8 hours
+    maxAge: 28800  // 8h heuristic default (LoA 2 internal) — not a policy value
   },
   cookies: {
     sessionToken: {
@@ -720,7 +896,7 @@ app.config.update(
     SESSION_COOKIE_HTTPONLY=True,
     SESSION_COOKIE_SECURE=True,
     SESSION_COOKIE_SAMESITE='Strict',
-    PERMANENT_SESSION_LIFETIME=timedelta(hours=8),
+    PERMANENT_SESSION_LIFETIME=timedelta(hours=8),  # Heuristic default — not a policy value
     SECRET_KEY=os.environ.get('SECRET_KEY')  # From env
 )
 ```
@@ -753,7 +929,7 @@ builder.Services.Configure<CookieAuthenticationOptions>(
         options.Cookie.HttpOnly = true;
         options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
         options.Cookie.SameSite = SameSiteMode.Strict;
-        options.ExpireTimeSpan = TimeSpan.FromHours(8);
+        options.ExpireTimeSpan = TimeSpan.FromHours(8); // Heuristic default — not a policy value
     });
 ```
 
@@ -775,18 +951,22 @@ builder.Services.Configure<CookieAuthenticationOptions>(
 
 | Check | ITSG-33 Control | Description |
 |-------|-----------------|-------------|
-| 3.1 Authorized IdP | IA-2, IA-8 | Identification and Authentication (Organizational Users, Non-Organizational Users) |
+| 3.1 Identity Providers | IA-2, IA-8 | Identification and Authentication (Organizational Users, Non-Organizational Users) |
 | 3.2 No Hardcoded Secrets | IA-5 | Authenticator Management |
-| 3.3 Discovery Endpoint | SC-8, SC-23 | Transmission Confidentiality, Session Authenticity |
-| 4.1 Cookie Flags | SC-8, SC-23 | Transmission Confidentiality, Session Authenticity |
-| 4.2 Session Timeout | AC-12, SC-10 | Session Termination, Network Disconnect |
-| 4.3 Token Storage | SC-28 | Protection of Information at Rest |
-| 5.1 Scope Minimization | AC-6 | Least Privilege |
-| 5.2 Server-side Claims | AC-4, SC-8 | Information Flow, Transmission Confidentiality |
-| 6.1 Session Clearing | AC-12 | Session Termination |
-| 6.2 Federated Logout | AC-12, IA-4 | Session Termination, Identifier Management |
-| 7.1 Server-side RBAC | AC-3, AC-6 | Access Enforcement, Least Privilege |
-| 7.2 Role Integrity | AC-3, SI-10 | Access Enforcement, Information Input Validation |
+| 3.3 Discovery Endpoint | SC-8, SC-23 | Transmission Confidentiality and Integrity, Session Authenticity |
+| 3.4 PKCE | SC-23 | Session Authenticity |
+| 3.5 State/Nonce Validation | SC-23 | Session Authenticity |
+| 3.6 Redirect URI Validation | SC-23, SI-10 | Session Authenticity, Information Input Validation |
+| 4.1 MFA Enforcement | IA-2(1), IA-2(2) | Identification and Authentication — Multi-factor Authentication (privileged and non-privileged accounts) |
+| 5.1 Cookie Flags | SC-8, SC-23 | Transmission Confidentiality and Integrity, Session Authenticity |
+| 5.2 Session Timeout | AC-12, SC-10 | Session Termination, Network Disconnect |
+| 5.3 Token Storage & Validation | SC-28, SC-23 | Protection of Information at Rest, Session Authenticity |
+| 6.1 Scope Minimization | AC-6 | Least Privilege |
+| 6.2 Server-side Claims | AC-4, SC-8 | Information Flow Enforcement, Transmission Confidentiality and Integrity |
+| 7.1 Session Clearing | AC-12 | Session Termination |
+| 7.2 Federated Logout | AC-12, IA-4 | Session Termination, Identifier Management |
+| 8.1 Server-side RBAC | AC-3, AC-6 | Access Enforcement, Least Privilege |
+| 8.2 Role Integrity | AC-3, SI-10 | Access Enforcement, Information Input Validation |
 
 ---
 
@@ -799,6 +979,12 @@ builder.Services.Configure<CookieAuthenticationOptions>(
 # Review specific files
 /gc-review-iam src/auth/**
 
-# Review with strict mode (warnings become failures)
+# Review with strict mode (warnings become failures — see Step 0; equivalent to iam.strictMode: true)
 /gc-review-iam --strict
 ```
+
+---
+
+## Disclaimer
+
+> **Disclaimer:** This is an automated pattern-based review and does not constitute a formal Security Assessment and Authorization (SA&A) or a formal compliance assessment. Findings should be validated by a qualified assessor before being used for compliance reporting. / **Avertissement :** Il s'agit d'une revue automatisée fondée sur des patrons; elle ne constitue pas une évaluation et autorisation de sécurité (EAS) officielle ni une évaluation officielle de conformité. Les constatations doivent être validées par un évaluateur qualifié avant d'être utilisées à des fins de rapports de conformité.


### PR DESCRIPTION
Implements all recommendations (R1–R7) from the gc-review-iam efficacy audit.

**Audit source:** `.gc-review/efficacy-audit/gc-review-iam.md` (local audit artifact — intentionally not committed).

| R# | Change |
|----|--------|
| R1 | Replaced the invented "8 hours per ITSG-33" session-timeout rule with ITSP.30.031 v3 assurance-level ceilings (≤ 12 h single-domain LoA 1–2; ≤ 30 min single-domain / ≤ 5 min cross-domain LoA 3; ITSG-33 AC-12/SC-10 organization-defined). Missing/unbounded timeout is now ❌ Fail; above-ceiling lifetime is ⚠️ Warning — resolving the previous Fail/Warning contradiction. 8 hours retained only as an explicitly labeled non-policy heuristic default. |
| R2 | Removed the fabricated "TBS Standard on Security Tabs"; remediation text now cites ITSG-33 IA-5 (Authenticator Management) and the Directive on Security Management (effective 2019-07-01), Appendix B. |
| R3 | Rewrote the Identity Providers section: no GC-designated IdP allow-list exists; anchored to Directive on Identity Management s. 4.1.9 (mandatory enterprise services). Documents actual usage per GC ICAM Framework v1.1 (external: GCKey, Interac Sign-In Partners, AB/BC provincial credentials via SSC GCCF `fjgc-gccf.gc.ca`; internal: SSC/departmental AD/Entra ID surface, ICM PKI/myKEY, GCpass). Sign In Canada marked maintenance-only since 2023-07-31; successor CanadaLogin (`login.canada.ca`, `app.login-connexion.canada.ca`) added to recognized issuers. Custom/self-built credential stores flagged as the compliance risk; consumer-IdP blanket ❌ downgraded to ⚠️ for public-facing services (config-declarable via `iam.publicFacing`), ❌ retained for internal/Protected B. |
| R4 | Corrected Standards Reference: dropped "updated 2023-03-01" from ITSG-33 (now Nov 2012 / Annex 3A Dec 2014); added ITSP.30.031 v3 (April 2018); dated the Guideline on Defining Authentication Requirements (Nov 2012); noted Directive on Service and Digital 2025-08-29 amendments; Last Verified refreshed to 2026-07-10. |
| R5 | Added missing checks: MFA enforcement (❌ if absent at LoA 3+/Protected B; Check 4.1), PKCE (❌ public clients, ⚠️ confidential; Check 3.4), state/nonce validation (Check 3.5), redirect-URI exact matching (Check 3.6), token `aud`/`iss` validation + `alg` allow-list rejecting `none` (Check 5.3). ITSG-33 mapping extended: MFA → IA-2(1)/(2); PKCE/state → SC-23; redirect URI → SC-23/SI-10. |
| R6 | Structural: `--strict` implemented as Step 0 argument parsing (promotes ⚠️→❌, wired to `iam.strictMode`); ASCII box-drawing report sections replaced with markdown headings/tables; added the "indicative, not literal regex" note; fixed the broken Check 7.1 regex (`[Authorize]` character class → `\[Authorize\]` etc.); fixed SC-8/AC-4 control names; added `skills/gc-review-iam/CONFIG.md` documenting the config schema (`version`, `iam.additionalIdPs`, `iam.assuranceLevel`, `iam.publicFacing`, `iam.strictMode`). |
| R7 | Added French instrument titles (Directive sur la gestion de l'identité, Norme sur l'assurance de l'identité et des justificatifs, Loi sur la protection des renseignements personnels, Directive sur les services et le numérique, etc.) per repo bilingual convention; SKILL.md closing disclaimer now bilingual. |

Also updated the root README gc-review-iam description and config subsections (EN + FR) to match the new checks and `iam`-namespaced config.

Deferred: none — all R1–R7 implemented.

Policy citations verified 2026-07-10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)