### PR TITLE
gc-review-all: implement efficacy-audit recommendations

### DIFF
--- a/skills/gc-review-all/SKILL.md
+++ b/skills/gc-review-all/SKILL.md
@@ -10,7 +10,7 @@ You are a **Government of Canada Compliance Audit Orchestrator**. Your role is t
 
 **Skill ID:** GOC-ALL-001
 **Sub-Skills:** gc-review-a11y, gc-review-security, gc-review-im, gc-review-iam, gc-review-branding, gc-review-bilingual
-**Last Verified:** 2026-03-26
+**Last Verified:** 2026-07-10
 
 ---
 
@@ -18,22 +18,47 @@ You are a **Government of Canada Compliance Audit Orchestrator**. Your role is t
 
 Execute these steps in order.
 
-### Step 0: Pre-flight Checks
+### Step 0: Pre-flight Checks & Scope Resolution
 
 Before launching agents, verify the environment:
 
+**1. Confirm git repository:**
+
 ```bash
-# 1. Confirm git repository
 git rev-parse --git-dir 2>/dev/null
-
-# 2. Confirm there are changes or code to review
-git diff --cached --stat || git diff --stat || git diff main...HEAD --stat 2>/dev/null
-
-# 3. List file types present (determines which skills are relevant)
-git ls-files | sed 's/.*\.//' | sort | uniq -c | sort -rn
 ```
 
 If the directory is not a git repository, inform the user and stop.
+
+**2. Check for changes in priority order** (run each command separately — do not chain them with `||`, since `git diff` exits 0 even when there are no changes):
+
+```bash
+# Check for staged changes first
+git diff --cached --stat
+
+# Then unstaged changes
+git diff --stat
+
+# If on a branch, compare to main/master
+git diff main...HEAD --stat 2>/dev/null || git diff master...HEAD --stat 2>/dev/null
+```
+
+**3. Decide the review scope (decision rule):**
+
+- If staged changes exist → resolved scope = **staged** (`git diff --cached`)
+- Else if unstaged changes exist → resolved scope = **unstaged** (`git diff`)
+- Else if the branch differs from main/master → resolved scope = **branch-diff** (`git diff main...HEAD`)
+- Else → resolved scope = **full-codebase** (no diff to review; skills review the whole project)
+
+**Record the resolved scope** (staged / unstaged / branch-diff / full-codebase) and the corresponding changed-file list (`git diff --name-only` with the matching arguments, or `git ls-files` for full-codebase). **Pass both into every sub-agent prompt in Step 3.**
+
+> **Scope note:** `gc-review-iam` and `gc-review-security` review the whole codebase or a provided scope regardless of the diff — an empty diff never skips them. The other four skills (a11y, im, branding, bilingual) are diff-based and use the resolved scope above.
+
+**4. List file types present** (determines which skills are relevant):
+
+```bash
+git ls-files | sed 's/.*\.//' | sort | uniq -c | sort -rn
+```
 
 ### Step 1: Determine Applicable Skills
 
@@ -41,12 +66,14 @@ Not every skill applies to every codebase. Use file-type detection to decide whi
 
 | Skill | Applies When These Files Exist |
 |-------|-------------------------------|
-| `gc-review-a11y` | `.html`, `.htm`, `.jsx`, `.tsx`, `.vue`, `.svelte`, `.css`, `.scss` |
-| `gc-review-security` | Any code files (`.js`, `.ts`, `.py`, `.java`, `.cs`, `.go`, `.rb`, `.php`, `.rs`, config files) |
-| `gc-review-im` | Database schemas, migrations, ORM models (`.sql`, `migration*`, `model*`, `schema*`) |
-| `gc-review-iam` | Auth-related files (`auth*`, `login*`, `session*`, `oidc*`, `.env`, config files with auth sections) |
-| `gc-review-branding` | `.html`, `.htm`, `.jsx`, `.tsx`, `.vue`, `.css`, `.scss`, image assets |
-| `gc-review-bilingual` | `.html`, `.jsx`, `.tsx`, `.vue`, locale/i18n directories, translation files (`.json`, `.yml`, `.po`) |
+| `gc-review-a11y` | UI files: `.html`, `.htm`, `.js`, `.jsx`, `.ts`, `.tsx`, `.vue`, `.svelte`, `.css`, `.scss`, `.sass`, `.less`, templates `.ejs`, `.hbs`, `.pug`, `.njk` |
+| `gc-review-security` | Any code files (`.js`, `.ts`, `.py`, `.java`, `.cs`, `.go`, `.rb`, `.php`, `.rs`, config files) — always runs |
+| `gc-review-im` | Database schemas, migrations, ORM models: `*.sql`, `**/migrations/**`, `*.prisma` (incl. `schema.prisma`), `*.entity.ts`, `**/entities/**`, `models.py`, `**/models/**`, `**/schemas/**`, `db/migrate/*.rb`, `app/models/*.rb`, plus data-access files containing delete calls (`DELETE FROM`, `.delete()`, `.destroy()`, `.remove()`) |
+| `gc-review-iam` | Auth-related files anywhere in the codebase (not just the diff): `auth*`, `login*`, `session*`, `oidc*`, `.env`, config files with auth sections |
+| `gc-review-branding` | Layouts/headers/footers in `.html`, `.htm`, `.jsx`, `.tsx`, `.vue`, `.svelte`; stylesheets `.css`, `.scss`, `.sass`, `.less`; server templates `.erb`, `.blade.php`, `.njk`, `.ejs`, `.hbs`, `.mustache`, `.liquid`; theme/token files `theme*.{ts,js,json}`, `tokens*.{ts,js,json}`; `tailwind.config.*`; image assets (`.svg`, `.png`) |
+| `gc-review-bilingual` | UI files `.html`, `.jsx`, `.tsx`, `.vue`, `.svelte`, templates `.ejs`, `.hbs`; locale/i18n directories; translation files (`.json`, `.yaml`, `.yml`); i18n config (`next.config.*`, `i18n.*`, `nuxt.config.*`) |
+
+> **Maintenance note:** This table mirrors each sub-skill's file-filter list — update both together.
 
 **Rules:**
 - `gc-review-security` always runs — every codebase has security surface.
@@ -55,7 +82,7 @@ Not every skill applies to every codebase. Use file-type detection to decide whi
 
 ### Step 2: Load Configuration
 
-Check for project-level configuration at `.gc-review/config.json`. If present and valid JSON with `"version": 1`, read any `gc-review-all` settings:
+Check for project-level configuration at `.gc-review/config.json`. If present and valid JSON with `"version": 1`, read the orchestrator's own settings from the `"gc-review-all"` namespace. Every sub-skill reads its own namespace from the same file (`"a11y"`, `"security"`, `"im"`, `"iam"`, `"branding"`, `"bilingual"`):
 
 ```json
 {
@@ -64,7 +91,13 @@ Check for project-level configuration at `.gc-review/config.json`. If present an
     "include": ["a11y", "security", "im", "iam", "branding", "bilingual"],
     "exclude": [],
     "parallel": true
-  }
+  },
+  "a11y": { "...": "see gc-review-a11y/CONFIG.md" },
+  "security": { "...": "see gc-review-security/CONFIG.md" },
+  "im": { "...": "see gc-review-im/CONFIG.md" },
+  "iam": { "...": "see gc-review-iam/CONFIG.md" },
+  "branding": { "...": "see gc-review-branding/CONFIG.md" },
+  "bilingual": { "...": "see the Configuration section of gc-review-bilingual/SKILL.md" }
 }
 ```
 
@@ -72,30 +105,179 @@ Check for project-level configuration at `.gc-review/config.json`. If present an
 - `exclude` — Skills to skip (overrides include)
 - `parallel` — Launch agents in parallel when available (default: true)
 
-Pass the full config through to each agent so individual skill settings are respected.
+**Config passthrough:** hold the full loaded JSON in memory. Each per-skill prompt template in Step 3 embeds it verbatim via the line `Project config (from .gc-review/config.json): {json or 'none'}` — each sub-skill picks out its own namespace.
+
+> **Deprecated fallbacks:** gc-review-a11y (legacy `./.a11y/config.json`) and gc-review-bilingual (legacy `.bilingual-review.json`) still honour their old config files for one release, with a deprecation warning in their reports. The orchestrator passes only `.gc-review/config.json`; the sub-skills handle their own legacy fallbacks.
 
 ### Step 3: Launch Agent Loop
 
-For each applicable skill, use the **Agent tool** to spawn a review agent with the following prompt template:
+**Resolve sub-skill paths before dispatch (do not hardcode a repo-relative `skills/…` path):**
+
+1. Locate the directory containing this orchestrator's own SKILL.md. Its parent is the skills root: `{skills_root}`.
+2. Each sub-skill lives at `{skills_root}/gc-review-{domain}/SKILL.md`.
+3. If a sibling is not found there, fall back to Glob: `**/gc-review-{domain}/SKILL.md` (exclude `node_modules`).
+4. If any applicable skill's SKILL.md still cannot be found, **stop before dispatch and report a hard error listing every missing skill**. Mark those domains as **INCOMPLETE** in the final report (Step 4/5) — do not silently skip them.
+
+For each applicable skill, use the **Agent tool** to spawn a review agent with that skill's prompt template below. Every template ends with the same **shared closing block**:
 
 ```
-You are running a GC compliance review sub-task.
-
-Read the skill file at: skills/gc-review-{domain}/SKILL.md
-
-Follow its workflow steps exactly:
-- Detect changes (Step 1)
-- Load config if applicable (Step 2)
-- Gather context (Step 3)
-- Run analysis (Step 4)
-- Present findings in the specified table format (Step 5)
-- Skip the fix selection step — report only
-
 Return your findings as a markdown table with columns:
 Status | File | Issue Found | Recommended Action
 
+Normalize all status icons to literal ❌/⚠️/✅ and count ❌ (Fail/Critical) findings as critical.
+
 End with a summary line:
 SUMMARY: {critical_count} critical, {warning_count} warnings, {pass_count} passes
+```
+
+#### Template — gc-review-a11y
+
+```
+You are running a GC compliance review sub-task: gc-review-a11y (accessibility).
+
+Read the skill file at: {skills_root}/gc-review-a11y/SKILL.md
+
+Review scope (resolved by the orchestrator): {staged | unstaged | branch-diff | full-codebase}
+Changed files: {file list}
+Project config (from .gc-review/config.json): {json or 'none'}
+
+This skill is diff-based. Follow its workflow:
+- Step 1: Detect Changes — use the scope above instead of re-deriving it
+- Step 2: Load Project Configuration — use the config above (a11y options are under the "a11y" namespace)
+- Step 3: Gather Context
+- Step 4: Run Accessibility Analysis
+- Step 5: Present Findings — this is the findings table
+- SKIP Step 6 (Fix Selection) — report only
+- Step 7: Summary — still produce the Summary counts
+
+{shared closing block}
+```
+
+#### Template — gc-review-security
+
+```
+You are running a GC compliance review sub-task: gc-review-security (Protected B security).
+
+Read the skill file at: {skills_root}/gc-review-security/SKILL.md
+Its sibling files are at {skills_root}/gc-review-security/checklist.md, {skills_root}/gc-review-security/report-template.md, and {skills_root}/gc-review-security/CONFIG.md.
+
+Review scope: {changed-file list, or 'entire codebase' when the resolved scope is full-codebase} — this skill reviews the whole codebase or the provided scope; it is not diff-gated
+Project config (from .gc-review/config.json): {json or 'none'}
+
+Follow the skill's 5-item Review Process:
+1. Detect changed files — use the scope above instead of re-running git diff
+2. Load configuration — use the config above (security options are under the "security" namespace)
+3. Evaluate each file in scope against the 6-point security checklist
+4. Categorize findings by ITSG-33 control family
+5. Output a structured findings table — the findings table lives in the "Output Format" section ("Security Review Results")
+
+There is no fix-selection step in this skill — it is report-only.
+
+{shared closing block}
+```
+
+#### Template — gc-review-im
+
+```
+You are running a GC compliance review sub-task: gc-review-im (information management).
+
+Read the skill file at: {skills_root}/gc-review-im/SKILL.md
+
+Review scope (resolved by the orchestrator): {staged | unstaged | branch-diff | full-codebase}
+Changed files: {file list}
+Project config (from .gc-review/config.json): {json or 'none'}
+
+This skill is diff-based. Follow its workflow — note that file identification (Step 2) comes BEFORE config loading (Step 3):
+- Step 1: Detect Changes — use the scope above instead of re-deriving it
+- Step 2: Identify IM-Relevant Files
+- Step 3: Load Configuration — use the config above (im options are under the "im" namespace)
+- Step 4: Review for IM Compliance — start with Step 4.0 (classify each model as business-value vs. transitory) before applying Categories A–D
+- Step 5: Present Findings — this is the findings table
+- Step 6: Summary
+
+There is no fix step in this skill.
+
+{shared closing block}
+```
+
+#### Template — gc-review-iam
+
+```
+You are running a GC compliance review sub-task: gc-review-iam (identity & authentication).
+
+Read the skill file at: {skills_root}/gc-review-iam/SKILL.md
+
+Review scope: this skill reviews the WHOLE CODEBASE (or a user-specified scope), not the diff — do not attempt change detection
+Project config (from .gc-review/config.json): {json or 'none'}
+
+Follow its workflow, Steps 0–9:
+- Step 0: Parse Arguments & Load Configuration — use the config above (iam options are under the "iam" namespace; pass --strict only if the user requested strict mode)
+- Step 1: Detect Project Context (stack detection)
+- Step 2: Identify Authentication-Related Files (across the whole codebase)
+- Step 3: OIDC Implementation & Protocol Security Review
+- Step 4: MFA Enforcement Review
+- Step 5: Session Security Review
+- Step 6: Scope & Claim Minimization Review
+- Step 7: Logout & Token Revocation Review
+- Step 8: RBAC Integration Review
+- Step 9: Generate Report — the findings table is section 9.3 (Detailed Findings)
+
+There is no fix step in this skill.
+
+{shared closing block}
+```
+
+#### Template — gc-review-branding
+
+```
+You are running a GC compliance review sub-task: gc-review-branding (FIP branding & design).
+
+Read the skill file at: {skills_root}/gc-review-branding/SKILL.md
+
+Review scope (resolved by the orchestrator): {staged | unstaged | branch-diff | full-codebase}
+Changed files: {file list}
+Project config (from .gc-review/config.json): {json or 'none'}
+
+This skill is diff-based. Follow its workflow, Steps 1–10 — note that config (Step 1) comes BEFORE change detection (Step 2), the reverse of most skills:
+- Step 1: Load Configuration — use the config above (branding options are under the "branding" namespace)
+- Step 2: Detect Changes — use the scope above instead of re-deriving it
+- Step 3: Identify Relevant Files
+- Step 4: FIP Symbol Check
+- Step 5: Language Toggle Check
+- Step 5b: Additional Header Elements Check
+- Step 6: Typography Audit
+- Step 7: Color Token Audit
+- Step 8: Component Consistency Check
+- Step 9: Footer Structure and Mandatory Links Check
+- Step 10: Present Compliance Report — the findings table is in its "Findings" section
+
+There is no fix-selection step in this skill.
+
+{shared closing block}
+```
+
+#### Template — gc-review-bilingual
+
+```
+You are running a GC compliance review sub-task: gc-review-bilingual (official languages).
+
+Read the skill file at: {skills_root}/gc-review-bilingual/SKILL.md
+
+Review scope (resolved by the orchestrator): {staged | unstaged | branch-diff | full-codebase}
+Changed files: {file list}
+Project config (from .gc-review/config.json): {json or 'none'}
+
+This skill is diff-based (it scans the full project when there are no changes). Follow its workflow:
+- Step 1: Detect Changes & Scope — use the scope above instead of re-deriving it
+- Step 2: Detect i18n Framework
+- Step 3: Locate Translation Files
+- Step 4: Run Rule Checks
+- Step 5: Present Results — the findings table is the "Detailed Findings" table
+- SKIP Step 6 (Fix Selection) — report only
+
+Bilingual options are under the "bilingual" namespace of the config above.
+
+{shared closing block}
 ```
 
 **Execution strategy:**
@@ -111,14 +293,25 @@ As each agent completes, collect its results into a unified structure:
 For each completed skill:
   - Domain tag: [A11Y], [SECURITY], [IM], [IAM], [BRANDING], [BILINGUAL]
   - Findings table rows (with domain tag prepended)
-  - Summary counts
+  - Summary counts (from the SUMMARY: line)
   - Compliance status (PASS / FAIL)
 ```
 
-Handle agent failures gracefully:
-- If an agent errors out → mark domain as **⚠️ Review Incomplete** and note the error
-- If an agent finds no applicable files → mark as **⏭️ Skipped**
-- If an agent completes → record PASS or FAIL
+**Severity normalization:** sub-skills use domain vocabularies inside their findings. Map them onto the repo severity convention before consolidating:
+
+| Sub-skill vocabulary | Normalized severity |
+|---|---|
+| `[Security Error: *]` (security), `[Auth Error]` (iam), `[Accessibility Error]` (a11y), `[IM Error]` (im), the label "Critical" (any skill) | ❌ **Fail** |
+| `[Security Warning: *]` (security), `[Auth Warning]` (iam), `[Accessibility Warning]` (a11y), `[IM Warning]` (im) | ⚠️ **Warning** |
+| Compliant / good-practice rows | ✅ **Pass** |
+
+"Critical" in the `SUMMARY:` line and in this consolidated report is the same level as ❌ **Fail** (the repo severity convention) — the Executive Summary column is therefore titled "❌ Fail", and `critical_count` = the number of ❌ Fail findings.
+
+**Handle agent failures gracefully:**
+- If an agent errors out → **retry it once**. If the retry also fails, mark the domain as **⚠️ INCOMPLETE** and note the error.
+- If a skill's SKILL.md could not be found in Step 3 → the domain is **⚠️ INCOMPLETE** (path-resolution error).
+- If an agent finds no applicable files → mark as **⏭️ Skipped**.
+- If an agent completes → record PASS or FAIL.
 
 ### Step 5: Present Consolidated Audit Report
 
@@ -130,24 +323,27 @@ Combine all results into this format:
 **Repository:** {repo name}
 **Branch:** {branch}
 **Date:** {date}
+**Review Scope:** {staged | unstaged | branch-diff | full-codebase}
 **Skills Executed:** {count} of 6
 
 ---
 
 ## Executive Summary
 
-| Domain | Status | ❌ Critical | ⚠️ Warnings | ✅ Passes |
-|--------|--------|------------|-------------|----------|
-| Accessibility (A11Y) | PASS/FAIL/SKIPPED | {n} | {n} | {n} |
-| Security | PASS/FAIL/SKIPPED | {n} | {n} | {n} |
-| Information Management | PASS/FAIL/SKIPPED | {n} | {n} | {n} |
-| Identity & Access Mgmt | PASS/FAIL/SKIPPED | {n} | {n} | {n} |
-| Branding & FIP | PASS/FAIL/SKIPPED | {n} | {n} | {n} |
-| Bilingual (OLA) | PASS/FAIL/SKIPPED | {n} | {n} | {n} |
+| Domain | Status | ❌ Fail | ⚠️ Warnings | ✅ Passes |
+|--------|--------|--------|-------------|----------|
+| Accessibility (A11Y) | PASS/FAIL/SKIPPED/INCOMPLETE | {n} | {n} | {n} |
+| Security | PASS/FAIL/SKIPPED/INCOMPLETE | {n} | {n} | {n} |
+| Information Management | PASS/FAIL/SKIPPED/INCOMPLETE | {n} | {n} | {n} |
+| Identity & Access Mgmt | PASS/FAIL/SKIPPED/INCOMPLETE | {n} | {n} | {n} |
+| Branding & FIP | PASS/FAIL/SKIPPED/INCOMPLETE | {n} | {n} | {n} |
+| Bilingual (OLA) | PASS/FAIL/SKIPPED/INCOMPLETE | {n} | {n} | {n} |
 | **TOTALS** | **{overall}** | **{n}** | **{n}** | **{n}** |
 
-**Overall Compliance:** PASS / FAIL
-(PASS = zero ❌ Critical across all domains; FAIL = one or more)
+**Overall Compliance:** PASS / FAIL / INCOMPLETE
+- **PASS** = zero ❌ Fail findings AND zero INCOMPLETE domains
+- **FAIL** = one or more ❌ Fail findings
+- **INCOMPLETE** = no ❌ Fail findings but at least one domain errored — name the errored domain(s); an unreviewed domain must never contribute to an overall PASS
 
 ---
 
@@ -179,7 +375,7 @@ After the audit report, produce a remediation plan that helps the team triage an
 
 ### Priority 1 — Critical Fixes (Must Address)
 
-Issues that block compliance. Fix these first.
+Issues that block compliance (❌ Fail). Fix these first.
 
 | # | Domain | File | Issue | Fix Description | Effort |
 |---|--------|------|-------|-----------------|--------|
@@ -228,9 +424,16 @@ Use AskUserQuestion to ask:
 
 If the user chooses to fix by domain, use AskUserQuestion to present the applicable domains.
 
-If the user chooses to fix issues, use the Agent tool to spawn domain-specific agents that have the appropriate tools (including Edit) to apply fixes. Each fix must be shown to the user and confirmed via AskUserQuestion before applying.
+**Fix protocol:** if the user chooses to fix issues, use the Agent tool to spawn fix agents with an **explicit tool grant of Read, Edit, and AskUserQuestion**. Fix agents follow *this orchestrator's* fix protocol — independent of the domain skill's own `allowed-tools` (most domain skills are report-only and declare no Edit):
 
-If the user chooses to export, use Bash to create the output directory (`mkdir -p .gc-review/reports`) and the Write tool to save to `.gc-review/reports/audit-{date}.md`.
+1. **Always show the proposed change first** (before/after code)
+2. Use AskUserQuestion to confirm: "Apply this fix?" (Yes / Skip / Stop)
+3. Only apply the change using the Edit tool after the user confirms
+4. Note what was changed in the final summary
+
+Never auto-apply fixes.
+
+If the user chooses to export, use Bash to create the output directory (`mkdir -p .gc-review/reports`) and the Write tool to save the report. **Filename:** `.gc-review/reports/audit-YYYY-MM-DD.md` (ISO date, e.g., `audit-2026-07-10.md`). If the file already exists, append `-2`, `-3`, … (e.g., `audit-2026-07-10-2.md`) — never overwrite a same-day report. Note: teams that gitignore `.gc-review/` should copy exported reports elsewhere to preserve audit history.
 
 ---
 
@@ -240,9 +443,9 @@ When the user requests an export, save to:
 
 ```
 .gc-review/
-├── config.json           (project config, if present)
+├── config.json                (project config, if present)
 └── reports/
-    └── audit-{date}.md   (full audit report + remediation plan)
+    └── audit-YYYY-MM-DD.md    (full audit report + remediation plan; -2, -3 suffix on collision)
 ```
 
 ---
@@ -263,7 +466,7 @@ When the user requests an export, save to:
 
 Your goal is a **single-pass, comprehensive compliance picture**. The value of this skill over running individual reviews is:
 
-1. **Completeness** — No domain is accidentally skipped
+1. **Completeness** — No domain is accidentally skipped, and an errored domain is surfaced as INCOMPLETE rather than silently passing
 2. **Cross-domain visibility** — A security issue might relate to an IAM finding; a branding issue might overlap with bilingual requirements
 3. **Prioritized action** — One ranked remediation list instead of six separate reports
 4. **Effort estimation** — Helps teams plan sprints and allocate work


### PR DESCRIPTION
Implements all nine recommendations (R1–R9) from the efficacy audit of the orchestrator skill.

> **Merge order: this PR must merge AFTER PRs #31–#36** — its prompt templates and applicability table are written against those branches' updated skill definitions.

## Changes

| R# | Change |
|----|--------|
| R1 | Replaced the single generic Step 3 prompt with six per-skill templates, each naming that skill's real steps as updated on its audit-fixes branch (a11y Steps 1–7 skip 6; security 5-item Review Process; im Steps 1–6 incl. Step 4.0 classification; iam Steps 0–9 findings at 9.3; branding Steps 1–10 incl. 5b; bilingual Steps 1–6 skip 6), its scope semantics, findings-table location, and fix-step handling. Shared closing block (4-column table + `SUMMARY:` line + icon-normalization instruction) kept in every template. |
| R2 | Runtime skill-path resolution: locate the orchestrator's own SKILL.md directory, load siblings from `{skills_root}/gc-review-{domain}/SKILL.md`, Glob fallback `**/gc-review-{domain}/SKILL.md` (excl. node_modules), hard pre-dispatch error listing missing skills feeding INCOMPLETE. No hardcoded repo-relative `skills/…` path remains. |
| R3 | Real config passthrough: Step 2 loads `.gc-review/config.json` (`"version": 1`, orchestrator options under `"gc-review-all"`, per-skill namespaces documented), and every template embeds the loaded config verbatim. Deprecated a11y/bilingual fallback files noted. |
| R4 | INCOMPLETE added to the Executive Summary status enum; overall rule now PASS = zero ❌ AND zero INCOMPLETE / FAIL = one or more ❌ / INCOMPLETE = no ❌ but an errored domain (named); retry-once before marking INCOMPLETE. |
| R5 | Severity normalization mapping table in Step 4 (`[Security Error: *]`, `[Auth Error]`, `[Accessibility Error]`, `[IM Error]`, "Critical" → ❌ Fail; warning tags → ⚠️ Warning); exec-summary column renamed to "❌ Fail" with the critical=Fail equivalence stated. |
| R6 | Step 1 applicability table regenerated from each updated skill's own file-filter list (a11y gains `.js/.ts/.sass/.less/.ejs/.hbs/.pug/.njk`; branding gains `.svelte`, server templates, theme/token files, `tailwind.config.*`; bilingual drops `.po`, gains `.yaml/.yml` + i18n config files; im gains `*.prisma`, entities, `db/migrate/*.rb`, delete-call data-access files). Maintenance note added. |
| R7 | Step 0 broken `||` chain replaced with three separate commands + decision rule (per a11y/im pattern); resolved scope (staged/unstaged/branch-diff/full-codebase) recorded and passed into every sub-agent prompt; iam/security noted as codebase-scoped regardless of diff. |
| R8 | Fix phase adopts option (a): fix agents spawned with an explicit tool grant (Read, Edit, AskUserQuestion) and follow the orchestrator's fix protocol (before/after shown, AskUserQuestion confirm per edit), independent of domain skills' own allowed-tools. |
| R9 | Export filename pinned to `audit-YYYY-MM-DD.md`, `-2`/`-3` suffix on collision; note that teams gitignoring `.gc-review/` should copy reports elsewhere. |

Also refreshed `Last Verified:` to 2026-07-10; bilingual disclaimer retained; `allowed-tools` unchanged and verified complete for the workflow.

**Deferred:** none — all nine recommendations implemented.

Audit source: `.gc-review/efficacy-audit/gc-review-all.md` (not committed).

Verified 2026-07-10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)